### PR TITLE
Add LSU stats

### DIFF
--- a/core/Fetch.cpp
+++ b/core/Fetch.cpp
@@ -73,7 +73,7 @@ namespace olympia
 
         out_fetch_queue_write_.send(insts_to_send);
 
-        credits_inst_queue_ -= insts_to_send->size();
+        credits_inst_queue_ -= static_cast<uint32_t> (insts_to_send->size());
 
         if((credits_inst_queue_ > 0) && (false == inst_generator_->isDone())) {
             fetch_inst_event_->schedule(1);

--- a/core/LSU.hpp
+++ b/core/LSU.hpp
@@ -523,6 +523,50 @@ namespace olympia
         // Flush load/store pipeline
         template<typename Comp>
         void flushLSPipeline_(const Comp &);
+
+        // Counters
+        sparta::Counter lsu_insts_dispatched_{
+            getStatisticSet(), "lsu_insts_dispatched",
+            "Number of LSU instructions dispatched", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter stores_retired_{
+            getStatisticSet(), "stores_retired",
+            "Number of stores retired", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter lsu_insts_issued_{
+            getStatisticSet(), "lsu_insts_issued",
+            "Number of LSU instructions issued", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter lsu_insts_completed_{
+            getStatisticSet(), "lsu_insts_completed",
+            "Number of LSU instructions completed", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter lsu_flushes_{
+            getStatisticSet(), "lsu_flushes",
+            "Number of instruction flushes at LSU", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter tlb_hits_{
+            getStatisticSet(), "tlb_hits",
+            "Number of TLB hits", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter tlb_misses_{
+            getStatisticSet(), "tlb_misses",
+            "Number of TLB misses", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter dl1_cache_hits_{
+            getStatisticSet(), "dl1_cache_hits",
+            "Number of DL1 cache hits", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter dl1_cache_misses_{
+            getStatisticSet(), "dl1_cache_misses",
+            "Number of DL1 cache misses", sparta::Counter::COUNT_NORMAL
+        };
+        sparta::Counter biu_reqs_{
+            getStatisticSet(), "biu_reqs",
+            "Number of BIU reqs", sparta::Counter::COUNT_NORMAL
+        };
+
+
     };
 
     inline std::ostream & operator<<(std::ostream & os,


### PR DESCRIPTION
Added a few additional LSU statistics. 

Output from running dhrystone trace:

```
        top.cpu.core0.lsu
            lsu_insts_dispatched                              = 5850001
            stores_retired                                    = 5850001
            lsu_insts_issued                                  = 11700073
            lsu_insts_completed                               = 5849999
            lsu_flushes                                       = 0
            tlb_hits                                          = 5850001
            tlb_misses                                        = 16
            dl1_cache_hits                                    = 5850000
            dl1_cache_misses                                  = 55
            biu_reqs                                          = 19

          top.cpu.core0.lsu.tlb
              tlb_hits                                        = 5850001
```

I will further look into the stats to make sure that they make sense. But the added stats can now be used for the purpose of the demo. 