### PR TITLE
Fixes for Github action failures

### DIFF
--- a/.github/actions/build/entrypoint.sh
+++ b/.github/actions/build/entrypoint.sh
@@ -21,7 +21,7 @@ mkdir -p release  # Link step expects "release" as dir name
 ln -s release fastdebug
 ln -s release debug
 cd release
-CC=gcc CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=$OLYMPIA_BUILD_TYPE -DGEN_DEBUG_INFO=OFF
+cmake .. -DCMAKE_BUILD_TYPE=$OLYMPIA_BUILD_TYPE -DGEN_DEBUG_INFO=OFF
 make -j2
 BUILD_SPARTA=$?
 if [ ${BUILD_SPARTA} -ne 0 ]; then
@@ -32,7 +32,7 @@ fi
 cd ${GITHUB_WORKSPACE}
 mkdir $OLYMPIA_BUILD_TYPE
 cd $OLYMPIA_BUILD_TYPE
-CC=gcc CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=$OLYMPIA_BUILD_TYPE -DGEN_DEBUG_INFO=OFF -DSPARTA_BASE=${GITHUB_WORKSPACE}/map/sparta
+cmake .. -DCMAKE_BUILD_TYPE=$OLYMPIA_BUILD_TYPE -DGEN_DEBUG_INFO=OFF -DSPARTA_BASE=${GITHUB_WORKSPACE}/map/sparta
 make -j2 regress
 BUILD_OLYMPIA=$?
 if [ ${BUILD_OLYMPIA} -ne 0 ]; then

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - bzip2=1.0.8=h7f98852_4
   - c-ares=1.18.1=h7f98852_0
   - ca-certificates=2022.12.7=ha878542_0
-  - cmake=3.15.5=hf94ab9c_0
+  - cmake=3.17.0=h28c56e5_0
   - cppcheck=2.7.5=py310h94ea96f_1
   - curl=7.87.0=h6312ad2_0
   - doxygen=1.8.20=had0d8f1_0


### PR DESCRIPTION
This PR fixes the failures we've been seeing in the Github Action Ubuntu regression script.

Fixes:
- Update CMake to version 3.17 to work around bug in https://gitlab.kitware.com/cmake/cmake/-/issues/20194
- Update to latest stf_lib (includes version check for CMake 3.17)
- Remove `CC` and `CXX` env var overrides from the build script
  - The build was attempting to use the Conda build environment with the system compilers, which caused linking errors