### PR TITLE
fix path for WeightedContextCounter

### DIFF
--- a/core/Dispatch.hpp
+++ b/core/Dispatch.hpp
@@ -16,7 +16,7 @@
 #include "sparta/statistics/ContextCounter.hpp"
 #include "sparta/simulation/ResourceFactory.hpp"
 
-#include "test/ContextCounter/WeightedContextCounter.hpp"
+#include "sparta/statistics/WeightedContextCounter.hpp"
 
 #include "Dispatcher.hpp"
 #include "CoreTypes.hpp"


### PR DESCRIPTION
the path of WeightedContextCounter has been changed to sparta/statistics, so fix it in this PR 