### PR TITLE
i2f Bug Fix

### DIFF
--- a/core/ExecutePipe.cpp
+++ b/core/ExecutePipe.cpp
@@ -3,6 +3,7 @@
 #include "sparta/utils/SpartaAssert.hpp"
 #include "sparta/utils/LogUtils.hpp"
 #include "ExecutePipe.hpp"
+#include "CoreUtils.hpp"
 
 namespace olympia
 {
@@ -139,8 +140,13 @@ namespace olympia
         ex_inst->setStatus(Inst::Status::COMPLETED);
 
         // set scoreboard
-        const auto & dest_bits = ex_inst->getDestRegisterBitMask(reg_file_);
-        scoreboard_views_[reg_file_]->setReady(dest_bits);
+        const auto & dests = ex_inst->getDestOpInfoList();
+        if(dests.size() > 0){
+            sparta_assert(dests.size() == 1); // we should only have one destination
+            core_types::RegFile reg_file_complete = olympia::coreutils::determineRegisterFile(dests[0]);
+            const auto & dest_bits = ex_inst->getDestRegisterBitMask(reg_file_complete);
+            scoreboard_views_[reg_file_complete]->setReady(dest_bits);
+        }
 
         // We're not busy anymore
         unit_busy_ = false;

--- a/test/core/rename/CMakeLists.txt
+++ b/test/core/rename/CMakeLists.txt
@@ -13,6 +13,7 @@ file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/expected_output  ${CMAKE_CURRENT_BI
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/rename_multiple_instructions.json  ${CMAKE_CURRENT_BINARY_DIR}/rename_multiple_instructions.json SYMBOLIC)
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/raw_integer.json  ${CMAKE_CURRENT_BINARY_DIR}/raw_integer.json SYMBOLIC)
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/raw_lsu.json  ${CMAKE_CURRENT_BINARY_DIR}/raw_lsu.json SYMBOLIC)
+file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/i2f.json  ${CMAKE_CURRENT_BINARY_DIR}/i2f.json SYMBOLIC)
 
 # Single add per cycle
 sparta_named_test(Rename_test_Run_Small  Rename_test small_core.out -c test_cores/test_small_core.yaml --input-file rename_multiple_instructions.json)
@@ -21,3 +22,4 @@ sparta_named_test(Rename_test_Run_Big    Rename_test big_core.out -c test_cores/
 sparta_named_test(Rename_test_Run_Big_Small_Rename    Rename_test big_core_small_rename.out -c test_cores/test_big_core_small_rename.yaml --input-file rename_multiple_instructions.json)
 sparta_named_test(Rename_test_Run_Small_lsu_dependency  Rename_test small_core.out -c test_cores/test_small_core_full.yaml --input-file raw_lsu.json)
 sparta_named_test(Rename_test_Run_Small_int_dependency  Rename_test small_core.out -c test_cores/test_medium_core_full.yaml --input-file raw_integer.json)
+sparta_named_test(Rename_test_i2f  Rename_test small_core.out -c test_cores/test_medium_core_full.yaml --input-file i2f.json)

--- a/test/core/rename/Rename_test.cpp
+++ b/test/core/rename/Rename_test.cpp
@@ -97,6 +97,11 @@ class olympia::RenameTester
             EXPECT_TRUE(rename.reference_counter_[0][34] == 0);
 
         }
+        void test_float(olympia::Rename & rename){
+            // ensure the correct register file is used
+            EXPECT_TRUE(rename.freelist_[1].size() == 94);
+            EXPECT_TRUE(rename.freelist_[0].size() == 96);
+        }
 };
 
 class olympia::ExecutePipeTester
@@ -395,6 +400,15 @@ void runTest(int argc, char **argv)
         executepipe_tester.test_dependent_integer_first_instruction(*my_executepipe);
         executepipe_tester.test_dependent_integer_second_instruction(*my_executepipe1);        
     }
+    else if(input_file == "i2f.json"){
+        cls.populateSimulation(&sim);
+        sparta::RootTreeNode* root_node = sim.getRoot();
+        olympia::Rename* my_rename = root_node->getChild("cpu.core0.rename")->getResourceAs<olympia::Rename*>();
+
+        olympia::RenameTester rename_tester;
+        cls.runSimulator(&sim, 4);
+        rename_tester.test_float(*my_rename);
+    }
     else if(input_file == "raw_lsu.json"){
         cls.populateSimulation(&sim);
         sparta::RootTreeNode* root_node = sim.getRoot();
@@ -417,13 +431,13 @@ void runTest(int argc, char **argv)
         olympia::Rename* my_rename = root_node->getChild("rename")->getResourceAs<olympia::Rename*>();
         olympia::RenameTester rename_tester;
         rename_tester.test_startup_rename_structures(*my_rename);
-        cls.runSimulator(& rename_sim, 2);
+        cls.runSimulator(&rename_sim, 2);
         rename_tester.test_one_instruction(*my_rename);
 
-        cls.runSimulator(& rename_sim, 3);
+        cls.runSimulator(&rename_sim, 3);
         rename_tester.test_multiple_instructions(*my_rename);
 
-        cls.runSimulator(& rename_sim);
+        cls.runSimulator(&rename_sim);
         rename_tester.test_clearing_rename_structures(*my_rename);
 
         EXPECT_FILES_EQUAL(datafiles[0], "expected_output/" + datafiles[0] + ".EXPECTED");

--- a/test/core/rename/i2f.json
+++ b/test/core/rename/i2f.json
@@ -1,0 +1,13 @@
+[
+    {
+        "mnemonic": "fmv.d.x",
+        "rs1": 1,
+        "fd": 17
+    },
+    {
+        "mnemonic": "fadd.d",
+        "fs1": 10,
+        "fs2": 17,
+        "fd": 7
+    }
+]

--- a/test/core/rename/raw_lsu.json
+++ b/test/core/rename/raw_lsu.json
@@ -11,10 +11,10 @@
         "vaddr" : "0xdeadbeef"
     },
     {
-    "mnemonic": "lw",
-    "rs1": 3,
-    "rs2": 4,
-    "rd":  5,
-    "vaddr" : "0xdeadbeef"
+        "mnemonic": "lw",
+        "rs1": 3,
+        "rs2": 4,
+        "rd":  5,
+        "vaddr" : "0xdeadbeef"
     }
 ]


### PR DESCRIPTION
Changing ExecutePipe.cpp code to set scoreboard based on destination register, not the pipe register. 
Added associated test for checking correct register file's rename registers are used.