### PR TITLE
Setup conda cache and ccache

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -44,9 +44,26 @@ jobs:
         with:
           python-version: 3.8
 
+      # Cache the conda dependencies to
+      - name: Cache conda deps
+        uses: actions/cache@v3
+        with:
+          key: ${{ matrix.os }}-${{ matrix.BUILD_TYPE }}-conda-${{ hashFiles('conda/environment.yml') }}
+          path: /usr/share/miniconda/envs/riscv_perf_model # Default path for conda
+
+      # Setup CCache to cache builds
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.os }}-${{ matrix.BUILD_TYPE }}-ccache-${{ github.ref_name }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.BUILD_TYPE }}-ccache-master
+            ${{ matrix.os }}-${{ matrix.BUILD_TYPE }}-ccache
+
       - name: Setup Conda Environment
         run: |
           # $CONDA is an environment variable pointing to the root of the miniconda directory
+          $CONDA/bin/conda config --set channel_priority strict
           $CONDA/bin/conda env update --file  ${{ github.workspace }}/conda/environment.yml
           $CONDA/bin/conda init bash
 


### PR DESCRIPTION
The goal of the PR is to improve build times.
Currently the build steps take around  > ~15 mins and most of the time is spent building sparta and the other dependencies.
This should bring it down to roughly ~6 mins.

CCache is used to cache build files, the cache for each branch is unique to prevent cache invalidation issues between different branches.

Conda dependencies are also cached although the time to build is not affected as much roughly  ~1 mins but would be higher if the network is slow.Conda spends a lot of time checking the dependencies.