### PR TITLE
Created the common Allocators class and hooked it up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,25 +55,13 @@ set (SIM_BASE ${PROJECT_SOURCE_DIR})
 set (OLYMPIA_VERSION "v0.1.0")
 add_definitions(-DOLYMPIA_VERSION=\"${OLYMPIA_VERSION}\")
 
-if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
-  set(SPARTA_BUILD_TYPE "release")
-elseif (CMAKE_BUILD_TYPE MATCHES "^[Ff]ast[Dd]ebug")
-  set(SPARTA_BUILD_TYPE "release")
-elseif (CMAKE_BUILD_TYPE MATCHES "^[Dd]ebug")
-  set(SPARTA_BUILD_TYPE "debug")
-elseif (CMAKE_BUILD_TYPE MATCHES "^[Pp]rofile")
-  set(SPARTA_BUILD_TYPE "release")
-else()
-  message (FATAL_ERROR "Please provide a CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=Release|FastDebug|Debug|Profile")
-endif()
-
 # Profile build flags
 set(CMAKE_CXX_FLAGS_PROFILE   "-O3 -pg -g -ftime-trace")
 set(CMAKE_CXX_FLAGS_FASTDEBUG "-O3 -g")
 set(CMAKE_CXX_FLAGS_DEBUG     "-O0 -g")
 
 # Include directories
-include_directories (core mss)
+include_directories (core mss sim)
 include_directories (SYSTEM mavis)
 include_directories (SYSTEM stf_lib)
 

--- a/core/CPUFactory.cpp
+++ b/core/CPUFactory.cpp
@@ -123,3 +123,8 @@ auto olympia::CPUFactory::getResourceNames() const -> const std::vector<std::str
 {
     return resource_names_;
 }
+
+// Destroy internal components
+void olympia::CPUFactory::deleteSubtree(sparta::ResourceTreeNode*) {
+    to_delete_.clear();
+}

--- a/core/CPUFactory.hpp
+++ b/core/CPUFactory.hpp
@@ -56,6 +56,9 @@ public:
     auto getResourceNames() const -> const std::vector<std::string>&;
 private:
 
+    //! Destroy internal components
+    void deleteSubtree(sparta::ResourceTreeNode*) override;
+
     /**
      * @brief Implementation : Build the device tree by instantiating resource nodes
      */

--- a/core/Execute.cpp
+++ b/core/Execute.cpp
@@ -39,4 +39,9 @@ namespace olympia
             }
         }
     }
+
+    void ExecuteFactory::deleteSubtree(sparta::ResourceTreeNode*) {
+        exe_pipe_tns_.clear();
+    }
+
 }

--- a/core/Execute.hpp
+++ b/core/Execute.hpp
@@ -49,6 +49,7 @@ namespace olympia
     {
     public:
         void onConfiguring(sparta::ResourceTreeNode* node) override;
+        void deleteSubtree(sparta::ResourceTreeNode*) override;
 
         ~ExecuteFactory() = default;
     private:

--- a/core/Inst.cpp
+++ b/core/Inst.cpp
@@ -4,7 +4,30 @@
 
 namespace olympia
 {
-    // This pipeline supports around 250 outstanding instructions.
-    InstAllocator         inst_allocator          (3000, 2500);
-    InstArchInfoAllocator inst_arch_info_allocator(3000, 2500);
+
+    /*!
+     * \brief Construct an Instruction
+     * \param opcode_info    Mavis Opcode information
+     * \param inst_arch_info Pointer to the static data of instruction
+     * \param clk            Core clock
+     *
+     * Called by Mavis when an opcode is decoded to a particular
+     * instruction.
+     */
+    Inst::Inst(const mavis::OpcodeInfo::PtrType& opcode_info,
+               const InstArchInfo::PtrType     & inst_arch_info,
+               const sparta::Clock             * clk) :
+        opcode_info_    (opcode_info),
+        inst_arch_info_ (inst_arch_info),
+        is_store_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::STORE)),
+        is_transfer_(miscutils::isOneOf(inst_arch_info_->getTargetPipe(),
+                                        InstArchInfo::TargetPipe::I2F,
+                                        InstArchInfo::TargetPipe::F2I)),
+
+        status_state_(Status::FETCHED)
+    {
+        sparta_assert(inst_arch_info_ != nullptr,
+                      "Mavis decoded the instruction, but Olympia has no uarch data for it: "
+                      << getDisasm() << " " << std::hex << " opc: 0x" << getOpCode());
+    }
 }

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -97,20 +97,7 @@ namespace olympia
         */
         Inst(const mavis::OpcodeInfo::PtrType& opcode_info,
              const InstArchInfo::PtrType     & inst_arch_info,
-             const sparta::Clock             * clk) :
-            opcode_info_    (opcode_info),
-            inst_arch_info_ (inst_arch_info),
-            is_store_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::STORE)),
-            is_transfer_(miscutils::isOneOf(inst_arch_info_->getTargetPipe(),
-                                            InstArchInfo::TargetPipe::I2F,
-                                            InstArchInfo::TargetPipe::F2I)),
-
-            status_state_(Status::FETCHED)
-        {
-            sparta_assert(inst_arch_info_ != nullptr,
-                          "Mavis decoded the instruction, but Olympia has no uarch data for it: "
-                          << getDisasm() << " " << std::hex << " opc: 0x" << getOpCode());
-        }
+             const sparta::Clock             * clk);
 
         // This is needed by Mavis as an optimization.  Try NOT to
         // implement it and let the compiler do it for us for speed.
@@ -311,8 +298,4 @@ namespace olympia
     // Instruction allocators
     using InstAllocator         = sparta::SpartaSharedPointerAllocator<Inst>;
     using InstArchInfoAllocator = sparta::SpartaSharedPointerAllocator<InstArchInfo>;
-
-    extern InstAllocator         inst_allocator;
-    extern InstArchInfoAllocator inst_arch_info_allocator;
-
 }

--- a/core/LSU.hpp
+++ b/core/LSU.hpp
@@ -58,16 +58,8 @@ namespace olympia
          */
         LSU(sparta::TreeNode* node, const LSUParameterSet* p);
 
-        ~LSU() {
-            DLOG(getContainer()->getLocation()
-                 << ": "
-                 << load_store_info_allocator.getNumAllocated()
-                 << " LoadStoreInstInfo objects allocated/created");
-            DLOG(getContainer()->getLocation()
-                 << ": "
-                 << memory_access_allocator.getNumAllocated()
-                 << " MemoryAccessInfo objects allocated/created");
-        }
+        //! Destroy the LSU
+        ~LSU();
 
         //! name of this resource.
         static const char name[];
@@ -90,9 +82,6 @@ namespace olympia
             COMPLETE = 2,       //4
             NUM_STAGES
         };
-
-        // allocator for this object type
-        sparta::SpartaSharedPointerAllocator<MemoryAccessInfo> memory_access_allocator;
 
         // Forward declaration of the Pair Definition class is must as we are friending it.
         class LoadStoreInstInfoPairDef;
@@ -186,7 +175,7 @@ namespace olympia
 
         };  // class LoadStoreInstInfo
 
-        sparta::SpartaSharedPointerAllocator<LoadStoreInstInfo> load_store_info_allocator;
+        using LoadStoreInstInfoAllocator = sparta::SpartaSharedPointerAllocator<LoadStoreInstInfo>;
 
         /*!
         * \class LoadStoreInstInfoPairDef
@@ -277,10 +266,15 @@ namespace olympia
         sparta::collection::Collectable<bool> cache_busy_collectable_{
             getContainer(), "dcache_busy", &cache_busy_};
 
+        // LSInstInfo allocator
+        LoadStoreInstInfoAllocator & load_store_info_allocator_;
+
+        // allocator for this object type
+        MemoryAccessInfoAllocator & memory_access_allocator_;
+
         // NOTE:
         // Depending on which kind of cache (e.g. blocking vs. non-blocking) is being used
         // This single slot could potentially be extended to a cache pending miss queue
-
 
         // Load/Store Pipeline
         using LoadStorePipeline = sparta::Pipeline<MemoryAccessInfoPtr>;
@@ -395,6 +389,11 @@ namespace olympia
             getStatisticSet(), "biu_reqs",
             "Number of BIU reqs", sparta::Counter::COUNT_NORMAL
         };
+
+
+        // When simulation is ending (error or not), this function
+        // will be called
+        void onStartingTeardown_() override {}
 
         friend class LSUTester;
 

--- a/core/MavisUnit.cpp
+++ b/core/MavisUnit.cpp
@@ -8,6 +8,8 @@
 #include "mavis/Mavis.h"
 #include "MavisUnit.hpp"
 
+#include "OlympiaAllocators.hpp"
+
 namespace olympia
 {
 
@@ -67,8 +69,10 @@ namespace olympia
         mavis_facade_ (new MavisType(getISAFiles(n, p->isa_file_path, pseudo_file_path_),
                                      getUArchFiles(n, p, p->uarch_file_path, pseudo_file_path_),
                                      mavis_uid_list_, getUArchAnnotationOverrides(p),
-                                     InstPtrAllocator<InstAllocator>        (inst_allocator),
-                                     InstPtrAllocator<InstArchInfoAllocator>(inst_arch_info_allocator)))
+                                     InstPtrAllocator<InstAllocator>
+                                     (sparta::notNull(OlympiaAllocators::getOlympiaAllocators(n))->inst_allocator),
+                                     InstPtrAllocator<InstArchInfoAllocator>
+                                     (sparta::notNull(OlympiaAllocators::getOlympiaAllocators(n))->inst_arch_info_allocator)))
     {}
 
     /**

--- a/core/MemoryAccessInfo.hpp
+++ b/core/MemoryAccessInfo.hpp
@@ -1,7 +1,15 @@
+// <MemoryAccessInfo.hpp> -*- C++ -*-
+
 #pragma once
 
-namespace olympia {
+#include "sparta/resources/Scoreboard.hpp"
+#include "sparta/pairs/SpartaKeyPairs.hpp"
+#include "sparta/utils/SpartaSharedPointer.hpp"
+#include "sparta/utils/SpartaSharedPointerAllocator.hpp"
 
+#include "Inst.hpp"
+
+namespace olympia {
 
     class MemoryAccessInfoPairDef;
 
@@ -99,9 +107,9 @@ namespace olympia {
     };
 
     /*!
-* \class MemoryAccessInfoPairDef
-* \brief Pair Definition class of the Memory Access Information that flows through the example/CoreModel
-*/
+     * \class MemoryAccessInfoPairDef
+     * \brief Pair Definition class of the Memory Access Information that flows through the example/CoreModel
+     */
 
     // This is the definition of the PairDefinition class of MemoryAccessInfo.
     // This PairDefinition class could be named anything but it needs to inherit
@@ -121,5 +129,6 @@ namespace olympia {
                               SPARTA_FLATTEN(&MemoryAccessInfo::getInstPtr))
     };
 
-    using MemoryAccessInfoPtr = sparta::SpartaSharedPointer<MemoryAccessInfo>;
+    using MemoryAccessInfoPtr       = sparta::SpartaSharedPointer<MemoryAccessInfo>;
+    using MemoryAccessInfoAllocator = sparta::SpartaSharedPointerAllocator<MemoryAccessInfo>;
 };

--- a/sim/OlympiaAllocators.hpp
+++ b/sim/OlympiaAllocators.hpp
@@ -1,0 +1,61 @@
+// <OlympiaAllocators.hpp> -*- C++ -*-
+
+#pragma once
+
+/*!
+ * \file OlympiaAllocators.hpp
+  * \brief Defines a general TreeNode that contains all allocators used
+ *        in simulation
+ */
+
+#include "sparta/simulation/TreeNode.hpp"
+
+#include "Inst.hpp"
+#include "MemoryAccessInfo.hpp"
+#include "LSU.hpp"  // A little heavyweight to include for now...
+
+namespace olympia
+{
+    /*!
+     * \class OlympiaAllocators
+     * \brief A TreeNode that is actually a functional resource
+     *        containing memory allocators
+     */
+    class OlympiaAllocators : public sparta::TreeNode
+    {
+    public:
+        static constexpr char name[] = "olympia_allocators";
+
+        OlympiaAllocators(sparta::TreeNode *node) :
+            sparta::TreeNode(node, name, "Allocators used in simulation")
+        {}
+
+        static OlympiaAllocators * getOlympiaAllocators(sparta::TreeNode *node)
+        {
+            OlympiaAllocators * allocators = nullptr;
+            if(node)
+            {
+                if(node->hasChild(OlympiaAllocators::name)) {
+                    // If this class is converted to a resource, use this line
+                    //allocators = node->getChild(OlympiaAllocators::name)->getResourceAs<OlympiaAllocators>();
+                    allocators = node->getChildAs<OlympiaAllocators>(OlympiaAllocators::name);
+                }
+                else {
+                    return getOlympiaAllocators(node->getParent());
+                }
+            }
+            return allocators;
+        }
+
+        // Allocators used in simulation.  These values can be
+        // parameterized in the future by converting this class into a
+        // full-blown sparta::Resource and adding a sparta::ParameterSet
+        InstAllocator         inst_allocator          {3000, 2500};
+        InstArchInfoAllocator inst_arch_info_allocator{3000, 2500};
+
+        // For LSU/MSS
+        LSU::LoadStoreInstInfoAllocator load_store_info_allocator{100, 80};
+        MemoryAccessInfoAllocator       memory_access_allocator  {100, 80};
+
+    };
+}

--- a/sim/OlympiaSim.hpp
+++ b/sim/OlympiaSim.hpp
@@ -4,7 +4,10 @@
 
 #include "sparta/app/Simulation.hpp"
 
-namespace olympia{ class CPUFactory; }
+namespace olympia {
+    class CPUFactory;
+    class OlympiaAllocators;
+}
 
 /*!
  * \brief OlympiaSim which builds the model and configures it
@@ -39,6 +42,13 @@ private:
 
     //////////////////////////////////////////////////////////////////////
     // Setup
+
+    // Allocators.  Last thing to delete
+    std::unique_ptr<olympia::OlympiaAllocators> allocators_tn_;
+
+    // The CPU TN.  This must be declared _AFTER_ the allocators so it
+    // is destroyed first.
+    std::unique_ptr<sparta::TreeNode> cpu_tn_to_delete_;
 
     //! Build the tree with tree nodes, but does not instantiate the
     //! unit yet

--- a/test/core/dispatch/Dispatch_test.cpp
+++ b/test/core/dispatch/Dispatch_test.cpp
@@ -2,6 +2,7 @@
 #include "Dispatch.hpp"
 #include "MavisUnit.hpp"
 #include "CoreUtils.hpp"
+#include "OlympiaAllocators.hpp"
 
 #include "test/core/common/SourceUnit.hpp"
 #include "test/core/common/SinkUnit.hpp"
@@ -68,6 +69,9 @@ private:
     void buildTree_()  override
     {
         auto rtn = getRoot();
+
+        // Cerate the common Allocators
+        allocators_tn_.reset(new olympia::OlympiaAllocators(rtn));
 
         sparta::ResourceTreeNode * disp = nullptr;
 
@@ -193,6 +197,8 @@ private:
         sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.in_lsu_credits"),
                      root_node->getChildAs<sparta::Port>("lsu.ports.out_sink_credits"));
     }
+    // Allocators.  Last thing to delete
+    std::unique_ptr<olympia::OlympiaAllocators> allocators_tn_;
 
     olympia::DispatchFactory     dispatch_fact;
     olympia::MavisFactoy         mavis_fact;

--- a/test/core/rename/Rename_test.cpp
+++ b/test/core/rename/Rename_test.cpp
@@ -6,6 +6,7 @@
 #include "ExecutePipe.hpp"
 #include "LSU.hpp"
 #include "sim/OlympiaSim.hpp"
+#include "OlympiaAllocators.hpp"
 
 #include "test/core/common/SourceUnit.hpp"
 #include "test/core/common/SinkUnit.hpp"
@@ -39,74 +40,74 @@ olympia::InstAllocator inst_allocator(2000, 1000);
 
 class olympia::RenameTester
 {
-    public:
-        void test_clearing_rename_structures(olympia::Rename & rename){
-            // after all instructions have retired, we should have:
-            // num_rename_registers - 32 registers = freelist size
-            // because we initialize the first 32 registers
-            if (rename.reference_counter_[0].size() == 34){
-                EXPECT_TRUE(rename.freelist_[0].size() == 2);
-                // in the case of only two free PRFs, they should NOT be equal to each other
-                EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
-            }
-            else{
-                EXPECT_TRUE(rename.freelist_[0].size() == 96);
-            }
-            // we're only expecting one reference
-            EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
-            EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
-
+public:
+    void test_clearing_rename_structures(olympia::Rename & rename){
+        // after all instructions have retired, we should have:
+        // num_rename_registers - 32 registers = freelist size
+        // because we initialize the first 32 registers
+        if (rename.reference_counter_[0].size() == 34){
+            EXPECT_TRUE(rename.freelist_[0].size() == 2);
+            // in the case of only two free PRFs, they should NOT be equal to each other
+            EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
         }
-        void test_one_instruction(olympia::Rename & rename){
-            // process only one instruction, check that freelist and map_tables are allocated correctly
-            if (rename.reference_counter_[0].size() == 34){
-                EXPECT_TRUE(rename.freelist_[0].size() == 1);
-            }
-            else{
-                EXPECT_TRUE(rename.freelist_[0].size() == 95);
-            }
-            // map table entry is valid, as it's been allocated
-            
-            // reference counters should now be 2 because the first instruction is:
-            // ADD x3 x1 x2 and both x1 -> prf1 and x2 -> prf2
-            EXPECT_TRUE(rename.reference_counter_[0][1] == 2);
-            EXPECT_TRUE(rename.reference_counter_[0][2] == 2);
-        }
-        void test_multiple_instructions(olympia::Rename & rename){
-            // first two instructions are RAW
-            // so the second instruction should increase reference count
-            EXPECT_TRUE(rename.reference_counter_[0][2] == 2);
-        }
-        void test_startup_rename_structures(olympia::Rename & rename){
-            // before starting, we should have:
-            // num_rename_registers - 32 registers = freelist size
-            // because we initialize the first 32 registers
-            if (rename.reference_counter_[0].size() == 34){
-                EXPECT_TRUE(rename.freelist_[0].size() == 2);
-            }
-            else{
-                EXPECT_TRUE(rename.freelist_[0].size() == 96);
-            }
-            // we're only expecting a value of 1 for registers x0 -> x31 because we initialize them
-            EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
-            EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
-            EXPECT_TRUE(rename.reference_counter_[0][30] == 1);
-            EXPECT_TRUE(rename.reference_counter_[0][31] == 1);
-            //
-            EXPECT_TRUE(rename.reference_counter_[0][33] == 0);
-            EXPECT_TRUE(rename.reference_counter_[0][34] == 0);
-
-        }
-        void test_float(olympia::Rename & rename){
-            // ensure the correct register file is used
-            EXPECT_TRUE(rename.freelist_[1].size() == 94);
+        else{
             EXPECT_TRUE(rename.freelist_[0].size() == 96);
         }
+        // we're only expecting one reference
+        EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
+        EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
+
+    }
+    void test_one_instruction(olympia::Rename & rename){
+        // process only one instruction, check that freelist and map_tables are allocated correctly
+        if (rename.reference_counter_[0].size() == 34){
+            EXPECT_TRUE(rename.freelist_[0].size() == 1);
+        }
+        else{
+            EXPECT_TRUE(rename.freelist_[0].size() == 95);
+        }
+        // map table entry is valid, as it's been allocated
+
+        // reference counters should now be 2 because the first instruction is:
+        // ADD x3 x1 x2 and both x1 -> prf1 and x2 -> prf2
+        EXPECT_TRUE(rename.reference_counter_[0][1] == 2);
+        EXPECT_TRUE(rename.reference_counter_[0][2] == 2);
+    }
+    void test_multiple_instructions(olympia::Rename & rename){
+        // first two instructions are RAW
+        // so the second instruction should increase reference count
+        EXPECT_TRUE(rename.reference_counter_[0][2] == 2);
+    }
+    void test_startup_rename_structures(olympia::Rename & rename){
+        // before starting, we should have:
+        // num_rename_registers - 32 registers = freelist size
+        // because we initialize the first 32 registers
+        if (rename.reference_counter_[0].size() == 34){
+            EXPECT_TRUE(rename.freelist_[0].size() == 2);
+        }
+        else{
+            EXPECT_TRUE(rename.freelist_[0].size() == 96);
+        }
+        // we're only expecting a value of 1 for registers x0 -> x31 because we initialize them
+        EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
+        EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
+        EXPECT_TRUE(rename.reference_counter_[0][30] == 1);
+        EXPECT_TRUE(rename.reference_counter_[0][31] == 1);
+        //
+        EXPECT_TRUE(rename.reference_counter_[0][33] == 0);
+        EXPECT_TRUE(rename.reference_counter_[0][34] == 0);
+
+    }
+    void test_float(olympia::Rename & rename){
+        // ensure the correct register file is used
+        EXPECT_TRUE(rename.freelist_[1].size() == 94);
+        EXPECT_TRUE(rename.freelist_[0].size() == 96);
+    }
 };
 
 class olympia::ExecutePipeTester
 {
-    public:
+public:
     void test_dependent_integer_first_instruction(olympia::ExecutePipe & executepipe){
         // testing RAW dependency for ExecutePipe
         // only alu0 should have an issued instruction
@@ -123,7 +124,7 @@ class olympia::ExecutePipeTester
 
 class olympia::LSUTester
 {
-    public:
+public:
     void test_dependent_lsu_instruction(olympia::LSU & lsu){
         // testing RAW dependency for LSU
         // we have an ADD instruction before we destination register 3
@@ -144,10 +145,10 @@ class RenameSim : public sparta::app::Simulation
 public:
 
     RenameSim(sparta::Scheduler * sched,
-                const std::string & mavis_isa_files,
-                const std::string & mavis_uarch_files,
-                const std::string & output_file,
-                const std::string & input_file) :
+              const std::string & mavis_isa_files,
+              const std::string & mavis_uarch_files,
+              const std::string & output_file,
+              const std::string & input_file) :
         sparta::app::Simulation("RenameSim", sched),
         input_file_(input_file),
         test_tap_(getRoot(), "info", output_file)
@@ -171,6 +172,9 @@ private:
     {
         auto rtn = getRoot();
 
+        // Cerate the common Allocators
+        allocators_tn_.reset(new olympia::OlympiaAllocators(rtn));
+
         sparta::ResourceTreeNode * disp = nullptr;
 
         // Create a Mavis Unit
@@ -183,18 +187,18 @@ private:
 
         // Create a Source Unit
         tns_to_delete_.emplace_back(new sparta::ResourceTreeNode(rtn,
-                                                                            core_test::SourceUnit::name,
-                                                                            sparta::TreeNode::GROUP_NAME_NONE,
-                                                                            sparta::TreeNode::GROUP_IDX_NONE,
-                                                                            "Source Unit",
-                                                                            &source_fact));
+                                                                 core_test::SourceUnit::name,
+                                                                 sparta::TreeNode::GROUP_NAME_NONE,
+                                                                 sparta::TreeNode::GROUP_IDX_NONE,
+                                                                 "Source Unit",
+                                                                 &source_fact));
         sparta::ResourceTreeNode * decode_unit = nullptr;
         tns_to_delete_.emplace_back(decode_unit = new sparta::ResourceTreeNode(rtn,
-                                                                            olympia::Decode::name,
-                                                                            sparta::TreeNode::GROUP_NAME_NONE,
-                                                                            sparta::TreeNode::GROUP_IDX_NONE,
-                                                                            "Decode Unit",
-                                                                            &source_fact));
+                                                                               olympia::Decode::name,
+                                                                               sparta::TreeNode::GROUP_NAME_NONE,
+                                                                               sparta::TreeNode::GROUP_IDX_NONE,
+                                                                               "Decode Unit",
+                                                                               &source_fact));
         decode_unit->getParameterSet()->getParameter("input_file")->setValueFromString(input_file_);
         // Create Dispatch
         tns_to_delete_.emplace_back(disp = new sparta::ResourceTreeNode(rtn,
@@ -203,14 +207,14 @@ private:
                                                                         sparta::TreeNode::GROUP_IDX_NONE,
                                                                         "Dispatch Unit",
                                                                         &dispatch_fact));
-        
+
         // Create Rename
         sparta::ResourceTreeNode * rename_unit = new sparta::ResourceTreeNode(rtn,
-                                                                        olympia::Rename::name,
-                                                                        sparta::TreeNode::GROUP_NAME_NONE,
-                                                                        sparta::TreeNode::GROUP_IDX_NONE,
-                                                                        "Test Rename",
-                                                                        &rename_fact);
+                                                                              olympia::Rename::name,
+                                                                              sparta::TreeNode::GROUP_NAME_NONE,
+                                                                              sparta::TreeNode::GROUP_IDX_NONE,
+                                                                              "Test Rename",
+                                                                              &rename_fact);
         tns_to_delete_.emplace_back(rename_unit);
 
         // Create SinkUnit that represents the ROB
@@ -287,7 +291,7 @@ private:
 
         sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.in_reorder_buffer_credits"),
                      root_node->getChildAs<sparta::Port>("rob.ports.out_sink_credits"));
-        
+
         // Bind the Rename ports
         sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.out_dispatch_queue_write"),
                      root_node->getChildAs<sparta::Port>("dispatch.ports.in_dispatch_queue_write"));
@@ -311,7 +315,7 @@ private:
             sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.out_"+unit_name+"_write"),
                          root_node->getChildAs<sparta::Port>(unit_name + ".ports.in_sink_retire_inst"));
             sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.in_rename_retire_ack"),
-                     root_node->getChildAs<sparta::Port>(unit_name+".ports.out_rob_retire_ack"));
+                         root_node->getChildAs<sparta::Port>(unit_name+".ports.out_rob_retire_ack"));
         }
 
         // Bind the "LSU" SinkUnit to Dispatch
@@ -324,9 +328,11 @@ private:
         sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.in_rename_retire_ack"),
                      root_node->getChildAs<sparta::Port>("lsu.ports.out_rob_retire_ack"));
     }
+    // Allocators.  Last thing to delete
+    std::unique_ptr<olympia::OlympiaAllocators> allocators_tn_;
 
     sparta::ResourceFactory<olympia::Decode,
-                                olympia::Decode::DecodeParameterSet> decode_fact;
+                            olympia::Decode::DecodeParameterSet> decode_fact;
     olympia::DispatchFactory        dispatch_fact;
     olympia::RenameFactory          rename_fact;
     olympia::MavisFactoy            mavis_fact;
@@ -383,11 +389,11 @@ void runTest(int argc, char **argv)
     uint32_t num_cores = 1;
     bool show_factories = false;
     OlympiaSim sim("simple",
-                    scheduler,
-                    num_cores, // cores
-                    input_file,
-                    ilimit,
-                    show_factories);
+                   scheduler,
+                   num_cores, // cores
+                   input_file,
+                   ilimit,
+                   show_factories);
 
     if(input_file == "raw_integer.json"){
         cls.populateSimulation(&sim);
@@ -398,7 +404,7 @@ void runTest(int argc, char **argv)
         olympia::ExecutePipeTester executepipe_tester;
         cls.runSimulator(&sim, 7);
         executepipe_tester.test_dependent_integer_first_instruction(*my_executepipe);
-        executepipe_tester.test_dependent_integer_second_instruction(*my_executepipe1);        
+        executepipe_tester.test_dependent_integer_second_instruction(*my_executepipe1);
     }
     else if(input_file == "i2f.json"){
         cls.populateSimulation(&sim);


### PR DESCRIPTION
Removed some dead code as well.

@h0lyalg0rithm, I added `void onStartingTeardown_() override {}` to the LSU in this PR as an example of what
I was talking about this morning.  This method is called every time just before the unit is destroyed -- either during an 
exception or a clean teardown.