### PR TITLE
Jeffnye.dromajo stf update

### DIFF
--- a/traces/README.md
+++ b/traces/README.md
@@ -122,7 +122,7 @@ git clone https://github.com/chipsalliance/dromajo
 
 # Checkout a Known-to-work SHA
 cd dromajo
-git checkout 6f68f74
+git checkout f3c3112
 
 # Apply the patch
 git apply ../dromajo_stf_lib.patch

--- a/traces/stf_trace_gen/dromajo_stf_lib.patch
+++ b/traces/stf_trace_gen/dromajo_stf_lib.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3f932a..70c6cb3 100644
+index a3f932a..9c93d56 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -39,7 +39,7 @@
@@ -11,6 +11,15 @@ index a3f932a..70c6cb3 100644
  project(dromajo)
  option(TRACEOS "TRACEOS" OFF)
  option(SIMPOINT "SIMPOINT" OFF)
+@@ -50,7 +50,7 @@ option(WARMUP "WARMUP" OFF)
+ 
+ add_compile_options(
+         -g
+-        -std=c++11
++        -std=c++17
+         -g
+         -Wall
+         -Wno-parentheses
 @@ -138,6 +138,22 @@ else ()
    target_link_libraries(dromajo_cosim_test dromajo_cosim)
  endif ()
@@ -35,19 +44,24 @@ index a3f932a..70c6cb3 100644
      include_directories(/usr/local/include /usr/local/include/libelf /opt/homebrew/include /opt/homebrew/include/libelf)
      target_link_libraries(dromajo_cosim -L/usr/local/lib -L/opt/homebrew/lib -lelf)
 diff --git a/include/dromajo_template.h b/include/dromajo_template.h
-index 2d8e9cc..8b1684d 100644
+index 2d8e9cc..7c54bfd 100644
 --- a/include/dromajo_template.h
 +++ b/include/dromajo_template.h
-@@ -52,6 +52,8 @@
+@@ -52,6 +52,13 @@
  #error unsupported XLEN
  #endif
  
++#include "../../trace_macros.h"
++#include "stf-inc/stf_writer.hpp"
++#include "stf-inc/stf_record_types.hpp"
++extern stf::STFWriter stf_writer;
++
 +#include <limits>
 +
  static inline intx_t glue(div, XLEN)(intx_t a, intx_t b) {
      if (b == 0) {
          return -1;
-@@ -278,6 +280,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
+@@ -278,6 +285,7 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
      }
  
      s->pending_exception = -1;
@@ -55,18 +69,126 @@ index 2d8e9cc..8b1684d 100644
      n_cycles++;
      /* Note: we assume NULL is represented as a zero number */
      code_ptr          = NULL;
+@@ -1807,6 +1815,92 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
+         }
+         /* update PC for next instruction */
+     jump_insn:;
++
++
++        // HERE HERE stf trace support
++      if(s->machine->common.vm_stf_trace) { //if cmd line specifies tracing
++
++        int hartid = 0; //FIXME
++        RISCVCPUState *cpu = s->machine->cpu_state[hartid];
++
++        bool isStart = insn == START_TRACE_OPC;
++        bool isStop  = insn == STOP_TRACE_OPC;
++        
++        if(isStart) {
++          s->machine->common.vm_stf_trace_enabled = true;
++          fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Started at 0x%lx\n", GET_PC());
++
++          s->machine->common.vm_stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;          
++
++          if((bool)stf_writer == false) {
++            stf_writer.open(s->machine->common.vm_stf_trace);
++            stf_writer.addTraceInfo(stf::TraceInfoRecord(
++                       stf::STF_GEN::STF_GEN_DROMAJO, 1, 1, 0,"Trace from Dromajo"));
++            stf_writer.setISA(stf::ISA::RISCV);
++            stf_writer.setHeaderIEM(stf::INST_IEM::STF_INST_IEM_RV64);
++            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_RV64);
++            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PHYSICAL_ADDRESS);
++            stf_writer.setHeaderPC(GET_PC());
++            stf_writer.finalizeHeader();
++          }
++        } else if(isStop) {
++          s->machine->common.vm_stf_trace_enabled = false;
++          fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Stopped at 0x%lx\n", GET_PC());
++          fprintf(dromajo_stderr, ">>> DROMAJO: Traced %ld insts\n",
++                                   s->machine->common.vm_stf_count);
++          stf_writer.close();
++        }
++
++        if(!isStart && s->machine->common.vm_stf_trace_enabled) {
++
++          //int priv = riscv_get_priv_level(cpu);
++          uint32_t insn_raw = insn;
++          uint64_t last_pc  = virt_machine_get_pc(s->machine, hartid);
++
++          if(s->machine->common.vm_no_stf_priv_check
++             || ((s->priv == 0)
++                 && (cpu->pending_exception == -1)
++                 && (s->machine->common.vm_stf_prog_asid == ((cpu->satp >> 4) & 0xFFFF))))
++          {
++            ++s->machine->common.vm_stf_count;
++            const uint32_t inst_width = ((insn_raw & 0x3) == 0x3) ? 4 : 2;
++            bool skip_record = false;
++            if(cpu->info != ctf_nop) {
++              stf_writer << stf::InstPCTargetRecord(GET_PC());
++            } else {
++
++              if(GET_PC() != last_pc + inst_width) {
++                  skip_record = true;
++              }
++            }
++
++            if(false == skip_record)
++            {
++              // If the last instruction were a load/store,
++              // record the last vaddr, size, and if it were a
++              // read or write.
++              if(cpu->last_data_vaddr
++                   != std::numeric_limits<decltype(cpu->last_data_vaddr)>::max())
++              {
++                  stf_writer << stf::InstMemAccessRecord(cpu->last_data_vaddr,
++                                                         cpu->last_data_size,
++                                                         0,
++                                                         (cpu->last_data_type == 0) ?
++                                                         stf::INST_MEM_ACCESS::READ :
++                                                         stf::INST_MEM_ACCESS::WRITE);
++                  stf_writer << stf::InstMemContentRecord(0); // empty content for now
++              }
++              
++              if(inst_width == 4) {
++                  stf_writer << stf::InstOpcode32Record(insn_raw);
++              }
++              else {
++                  stf_writer << stf::InstOpcode16Record(insn_raw & 0xFFFF);
++              }
++            }
++          }
++        }
++      }
+     } /* end of main loop */
+ illegal_insn:
+     s->pending_exception = CAUSE_ILLEGAL_INSTRUCTION;
 diff --git a/include/machine.h b/include/machine.h
-index c359091..6bf16b3 100644
+index c359091..ed6dac8 100644
 --- a/include/machine.h
 +++ b/include/machine.h
-@@ -205,6 +205,7 @@ typedef struct VirtMachine {
-     char *   terminate_event;
+@@ -142,6 +142,8 @@ typedef struct {
+     VMEthEntry       tab_eth[MAX_ETH_DEVICE];
+     int              eth_count;
+     uint64_t         htif_base_addr;
++    uint64_t         htif_tohost;
++    uint64_t         htif_fromhost;
+ 
+     char *cmdline;      /* bios or kernel command line */
+     BOOL  accel_enable; /* enable acceleration (KVM) */
+@@ -206,6 +208,13 @@ typedef struct VirtMachine {
      uint64_t maxinsns;
      uint64_t trace;
-+    const char * stf_trace = nullptr;
  
++    const char *   vm_stf_trace = nullptr; //stf file
++    bool           vm_stf_trace_enabled; 
++    bool           vm_no_stf_priv_check; //disable privilege checks in trace generation
++    uint64_t       vm_stf_prog_asid;
++    uint64_t       vm_stf_count;
++    uint64_t       vm_stf_first;
++
      /* For co-simulation only, they are -1 if nothing is pending. */
      bool cosim;
+     int  pending_interrupt;
 diff --git a/include/riscv_cpu.h b/include/riscv_cpu.h
 index 2f71c99..2de97a3 100644
 --- a/include/riscv_cpu.h
@@ -81,212 +203,107 @@ index 2f71c99..2de97a3 100644
  #ifdef GOLDMEM_INORDER
      target_ulong last_data_value;
  #endif
-diff --git a/run/boot.cfg b/run/boot.cfg
-index b220030..d80fb22 100644
---- a/run/boot.cfg
-+++ b/run/boot.cfg
-@@ -5,6 +5,6 @@
-     "bios":"fw_jump.bin",
-     "kernel":"Image",
-     "initrd":"rootfs.cpio",
--    "cmdline": "root=/dev/ram rw earlycon=sbi console=hvc0 bench=spec06_gcc",
-+    "cmdline": "root=/dev/ram rw earlycon=sbi console=hvc0",
-     "memory_base_addr":0x80000000
- }
 diff --git a/src/dromajo.cpp b/src/dromajo.cpp
-index c13239a..e27f709 100644
+index c13239a..0cb0754 100644
 --- a/src/dromajo.cpp
 +++ b/src/dromajo.cpp
-@@ -46,6 +46,11 @@
+@@ -46,6 +46,10 @@
  #include "dromajo_cosim.h"
  #endif
  
-+
-+#include "../../trace_macros.h"
 +#include "stf-inc/stf_writer.hpp"
 +#include "stf-inc/stf_record_types.hpp"
++stf::STFWriter stf_writer;
 +
  #ifdef SIMPOINT_BB
  FILE *simpoint_bb_file = nullptr;
  int   simpoint_roi     = 0;  // start without ROI enabled
-@@ -121,6 +126,14 @@ int simpoint_step(RISCVMachine *m, int hartid) {
- }
- #endif
+diff --git a/src/dromajo_cosim.cpp b/src/dromajo_cosim.cpp
+index 24faded..2ae8bbf 100644
+--- a/src/dromajo_cosim.cpp
++++ b/src/dromajo_cosim.cpp
+@@ -27,6 +27,11 @@
+ #include "iomem.h"
+ #include "riscv_machine.h"
  
-+////////////////////////////////////////////////////////////////////////////////
-+// STF Writing
-+stf::STFWriter stf_writer;
-+bool tracing_enabled = false;
-+uint64_t stf_prog_asid = 0;
-+uint64_t stf_count = 0;
-+////////////////////////////////////////////////////////////////////////////////
++//STF: cosim shares riscv_cpu_interp, dromajo_template.h
++#include "stf-inc/stf_writer.hpp"
++#include "stf-inc/stf_record_types.hpp"
++stf::STFWriter stf_writer; 
 +
- static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
-     m->common.maxinsns -= n_cycles;
- 
-@@ -143,10 +156,96 @@ static int iterate_core(RISCVMachine *m, int hartid, int n_cycles) {
-         n_cycles = 1;
-         do_trace = true;
-     } else
--      m->common.trace -= n_cycles;
-+        m->common.trace -= n_cycles;
- 
-     int keep_going = virt_machine_run(m, hartid, n_cycles);
- 
-+    if(m->common.stf_trace) {
-+        // check for start trace marker
-+        if(insn_raw == START_TRACE_OPC)
-+        {
-+            tracing_enabled = true;
-+            fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Started at 0x%lx\n", virt_machine_get_pc(m, 0));
-+            stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;
-+            if((bool)stf_writer == false) {
-+                stf_writer.open(m->common.stf_trace);
-+                stf_writer.
-+                    addTraceInfo(stf::TraceInfoRecord(stf::STF_GEN::STF_GEN_DROMAJO, 1, 1, 0,
-+                                                      "Trace from Dromajo"));
-+                stf_writer.setISA(stf::ISA::RISCV);
-+                stf_writer.setHeaderIEM(stf::INST_IEM::STF_INST_IEM_RV64);
-+                stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_RV64);
-+                stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PHYSICAL_ADDRESS);
-+                stf_writer.setHeaderPC(virt_machine_get_pc(m, 0));
-+                stf_writer.finalizeHeader();
-+            }
-+
-+            return keep_going;
-+        }
-+        else if (insn_raw == STOP_TRACE_OPC) {
-+            tracing_enabled = false;
-+            stf_writer.close();
-+            fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Stopped at 0x%lx\n", virt_machine_get_pc(m, 0));
-+            fprintf(dromajo_stderr, ">>> DROMAJO: Traced %ld insts\n", stf_count);
-+        }
-+
-+        if(tracing_enabled)
-+        {
-+            // Only trace in user priv and the same application that
-+            // started the trace
-+            if((priv == 0) &&
-+               (cpu->pending_exception == -1) &&
-+               (stf_prog_asid == ((cpu->satp >> 4) & 0xFFFF)))
-+            {
-+                ++stf_count;
-+                const uint32_t inst_width = ((insn_raw & 0x3) == 0x3) ? 4 : 2;
-+                bool skip_record = false;
-+
-+                // See if the instruction changed control flow or a
-+                // possible not-taken branch conditional
-+                if(cpu->info != ctf_nop) {
-+                    stf_writer << stf::InstPCTargetRecord(virt_machine_get_pc(m, 0));
-+                }
-+                else {
-+                    // Not sure what's going on, but there's a
-+                    // possibility that the current instruction will
-+                    // cause a page fault or a timer interrupt or
-+                    // process switch so the next instruction might
-+                    // not be on the program's path
-+                    if(cpu->pc != last_pc + inst_width) {
-+                        skip_record = true;
-+                    }
-+                }
-+
-+                // Record the instruction trace record
-+                if(false == skip_record)
-+                {
-+                    // If the last instruction were a load/store,
-+                    // record the last vaddr, size, and if it were a
-+                    // read or write.
-+                    if(cpu->last_data_vaddr != std::numeric_limits<decltype(cpu->last_data_vaddr)>::max())
-+                    {
-+                        stf_writer << stf::InstMemAccessRecord(cpu->last_data_vaddr,
-+                                                               cpu->last_data_size,
-+                                                               0,
-+                                                               (cpu->last_data_type == 0) ?
-+                                                               stf::INST_MEM_ACCESS::READ :
-+                                                               stf::INST_MEM_ACCESS::WRITE);
-+                        stf_writer << stf::InstMemContentRecord(0); // empty content for now
-+                    }
-+
-+                    if(inst_width == 4) {
-+                        stf_writer << stf::InstOpcode32Record(insn_raw);
-+                    }
-+                    else {
-+                        stf_writer << stf::InstOpcode16Record(insn_raw & 0xFFFF);
-+                    }
-+                }
-+            }
-+        }
-+        return keep_going;
-+    }
-+
-     if (!do_trace) {
-         return keep_going;
-     }
-@@ -223,7 +322,7 @@ int main(int argc, char **argv) {
-     if (!m)
-         return 1;
- 
--    int n_cycles = 10000;
-+    int n_cycles = 1;
-     execution_start_ts = get_current_time_in_seconds();
-     execution_progress_meassure = &m->cpu_state[0]->minstret;
-     signal(SIGINT, sigintr_handler);
+ #ifdef GOLDMEM_INORDER
+ void check_inorder_load(int cid, uint64_t addr, uint8_t sz, uint64_t ld_data, bool io_map);
+ void check_inorder_store(int cid, uint64_t addr, uint8_t sz, uint64_t st_data, bool io_map);
 diff --git a/src/dromajo_main.cpp b/src/dromajo_main.cpp
-index aeb1912..2fdaef2 100644
+index aeb1912..3369f79 100644
 --- a/src/dromajo_main.cpp
 +++ b/src/dromajo_main.cpp
 @@ -560,6 +560,7 @@ static void usage(const char *prog, const char *msg) {
              "       --maxinsns terminates execution after a number of instructions\n"
              "       --terminate-event name of the validate event to terminate execution\n"
              "       --trace start trace dump after a number of instructions. Trace disabled by default\n"
-+	     "       --stf_trace <filename>  Dump an STF trace to the given file\n"
++            "       --stf_trace <filename>  Dump an STF trace to the given file\n"
              "       --ignore_sbi_shutdown continue simulation even upon seeing the SBI_SHUTDOWN call\n"
              "       --dump_memories dump memories that could be used to load a cosimulation\n"
              "       --memory_size sets the memory size in MiB (default 256 MiB)\n"
-@@ -618,6 +619,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
+@@ -571,6 +572,7 @@ static void usage(const char *prog, const char *msg) {
+             "       --plic START:SIZE set PLIC start address and size in B (defaults to 0x%lx:0x%lx)\n"
+             "       --clint START:SIZE set CLINT start address and size in B (defaults to 0x%lx:0x%lx)\n"
+             "       --custom_extension add X extension to misa for all cores\n"
++            "       --no_stf_priv_check Turn off the privledge check in STF generation\n"
+ #ifdef LIVECACHE
+             "       --live_cache_size live cache warmup for checkpoint (default 8M)\n"
+ #endif
+@@ -618,10 +620,12 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
      long        ncpus                    = 0;
      uint64_t    maxinsns                 = 0;
      uint64_t    trace                    = UINT64_MAX;
-+    const char *stf_trace                = nullptr;
++    const char *stf_trace                = NULL;
      long        memory_size_override     = 0;
      uint64_t    memory_addr_override     = 0;
      bool        ignore_sbi_shutdown      = false;
-@@ -640,7 +642,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
-     bool        allow_ctrlc              = false;
- 
-     dromajo_stdout = stdout;
--    dromajo_stderr = stderr;
-+    dromajo_stderr = stdout;
- 
-     optind = 0;
- 
-@@ -654,6 +656,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
-             {"save",                    required_argument, 0,  's' },
+     bool        dump_memories            = false;
++    bool        no_stf_priv_check        = false;
+     char *      bootrom_name             = 0;
+     char *      dtb_name                 = 0;
+     bool        compact_bootrom          = false;
+@@ -655,6 +659,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
              {"simpoint",                required_argument, 0,  'S' },
              {"maxinsns",                required_argument, 0,  'm' }, // CFG
-+	     {"stf_trace",               required_argument, 0,  'z' },
              {"trace   ",                required_argument, 0,  't' },
++            {"stf_trace",               required_argument, 0,  'z' },
              {"ignore_sbi_shutdown",     required_argument, 0,  'P' }, // CFG
              {"dump_memories",                 no_argument, 0,  'D' }, // CFG
-@@ -734,6 +737,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
+             {"memory_size",             required_argument, 0,  'M' }, // CFG
+@@ -668,6 +673,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
+             {"custom_extension",              no_argument, 0,  'u' }, // CFG
+             {"clear_ids",                     no_argument, 0,  'L' }, // CFG
+             {"ctrlc",                         no_argument, 0,  'X' },
++            {"no_stf_priv_check",             no_argument, 0,  'a' },
+ #ifdef LIVECACHE
+             {"live_cache_size",         required_argument, 0,  'w' }, // CFG
+ #endif
+@@ -734,6 +740,9 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
                  trace = (uint64_t)atoll(optarg);
                  break;
  
-+	    case 'z':
-+		stf_trace = strdup(optarg);
-+		break;
++            case 'z': stf_trace = strdup(optarg); break;
++            case 'a': no_stf_priv_check = true; break;
 +
              case 'P': ignore_sbi_shutdown = true; break;
  
              case 'D': dump_memories = true; break;
-@@ -1058,6 +1065,7 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
- 
+@@ -1059,6 +1068,10 @@ RISCVMachine *virt_machine_main(int argc, char **argv) {
      s->common.snapshot_save_name = snapshot_save_name;
      s->common.trace              = trace;
-+    s->common.stf_trace          = stf_trace;
  
++    s->common.vm_stf_trace         = stf_trace;
++    s->common.vm_no_stf_priv_check = no_stf_priv_check;
++    s->common.vm_stf_trace_enabled = false;
++
      // Allow the command option argument to overwrite the value
      // specified in the configuration file
+     if (maxinsns > 0) {
 diff --git a/src/riscv_cpu.cpp b/src/riscv_cpu.cpp
 index c7e8926..9c49919 100644
 --- a/src/riscv_cpu.cpp
@@ -311,27 +328,3 @@ index c7e8926..9c49919 100644
      //printf("track.ld[%llx:%llx]=%llx\n", paddr, paddr+size-1, data);
  
      return data;
-diff --git a/src/riscv_machine.cpp b/src/riscv_machine.cpp
-index 195fe40..d110a5d 100644
---- a/src/riscv_machine.cpp
-+++ b/src/riscv_machine.cpp
-@@ -413,8 +413,9 @@ static void plic_set_irq(void *opaque, int irq_num, int state) {
-     }
- }
- 
--static uint8_t *get_ram_ptr(RISCVMachine *s, uint64_t paddr) {
-+static uint8_t *get_ram_ptr(RISCVMachine *s, uint64_t paddr, size_t size = 0) {
-     PhysMemoryRange *pr = get_phys_mem_range(s->mem_map, paddr);
-+    assert(size < pr->size);
-     if (!pr || !pr->is_ram)
-         return NULL;
-     return pr->phys_mem + (uintptr_t)(paddr - pr->addr);
-@@ -891,7 +892,7 @@ void load_elf_image(RISCVMachine *s, const uint8_t *image, size_t image_len) {
-                    can't fix this without a substantial rewrite as the handling of IO devices
-                    depends on this. */
-                 cpu_register_ram(s->mem_map, ph->p_vaddr, rounded_size, 0);
--            memcpy(get_ram_ptr(s, ph->p_vaddr), image + ph->p_offset, ph->p_filesz);
-+	    memcpy(get_ram_ptr(s, ph->p_vaddr, ph->p_filesz), image + ph->p_offset, ph->p_filesz);
-         }
- }
- 

--- a/traces/stf_trace_gen/dromajo_stf_lib.patch
+++ b/traces/stf_trace_gen/dromajo_stf_lib.patch
@@ -1,5 +1,5 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index a3f932a..9c93d56 100644
+index a3f932a..a955816 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -39,7 +39,7 @@
@@ -20,7 +20,7 @@ index a3f932a..9c93d56 100644
          -g
          -Wall
          -Wno-parentheses
-@@ -138,6 +138,22 @@ else ()
+@@ -138,6 +138,25 @@ else ()
    target_link_libraries(dromajo_cosim_test dromajo_cosim)
  endif ()
  
@@ -35,6 +35,9 @@ index a3f932a..9c93d56 100644
 +target_link_directories(dromajo PRIVATE ${STF_LIB_BASE}/build/lib)
 +target_link_libraries(dromajo ${STF_LINK_LIBS})
 +
++target_link_directories(dromajo_cosim PRIVATE ${STF_LIB_BASE}/build/lib)
++target_link_libraries(dromajo_cosim ${STF_LINK_LIBS})
++
 +# Add STF library to the build
 +add_subdirectory (${STF_LIB_BASE})
 +
@@ -44,7 +47,7 @@ index a3f932a..9c93d56 100644
      include_directories(/usr/local/include /usr/local/include/libelf /opt/homebrew/include /opt/homebrew/include/libelf)
      target_link_libraries(dromajo_cosim -L/usr/local/lib -L/opt/homebrew/lib -lelf)
 diff --git a/include/dromajo_template.h b/include/dromajo_template.h
-index 2d8e9cc..7c54bfd 100644
+index 2d8e9cc..a0a4bab 100644
 --- a/include/dromajo_template.h
 +++ b/include/dromajo_template.h
 @@ -52,6 +52,13 @@
@@ -83,12 +86,12 @@ index 2d8e9cc..7c54bfd 100644
 +
 +        bool isStart = insn == START_TRACE_OPC;
 +        bool isStop  = insn == STOP_TRACE_OPC;
-+        
++
 +        if(isStart) {
 +          s->machine->common.vm_stf_trace_enabled = true;
 +          fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Started at 0x%lx\n", GET_PC());
 +
-+          s->machine->common.vm_stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;          
++          s->machine->common.vm_stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;
 +
 +          if((bool)stf_writer == false) {
 +            stf_writer.open(s->machine->common.vm_stf_trace);
@@ -148,7 +151,7 @@ index 2d8e9cc..7c54bfd 100644
 +                                                         stf::INST_MEM_ACCESS::WRITE);
 +                  stf_writer << stf::InstMemContentRecord(0); // empty content for now
 +              }
-+              
++
 +              if(inst_width == 4) {
 +                  stf_writer << stf::InstOpcode32Record(insn_raw);
 +              }
@@ -163,10 +166,19 @@ index 2d8e9cc..7c54bfd 100644
  illegal_insn:
      s->pending_exception = CAUSE_ILLEGAL_INSTRUCTION;
 diff --git a/include/machine.h b/include/machine.h
-index c359091..ed6dac8 100644
+index c359091..41b3b01 100644
 --- a/include/machine.h
 +++ b/include/machine.h
-@@ -142,6 +142,8 @@ typedef struct {
+@@ -41,6 +41,8 @@
+ #include <stdint.h>
+ 
+ #include "json.h"
++#include "stf-inc/stf_writer.hpp"
++#include "stf-inc/stf_record_types.hpp"
+ 
+ typedef struct RISCVMachine RISCVMachine;
+ 
+@@ -142,6 +144,8 @@ typedef struct {
      VMEthEntry       tab_eth[MAX_ETH_DEVICE];
      int              eth_count;
      uint64_t         htif_base_addr;
@@ -175,12 +187,12 @@ index c359091..ed6dac8 100644
  
      char *cmdline;      /* bios or kernel command line */
      BOOL  accel_enable; /* enable acceleration (KVM) */
-@@ -206,6 +208,13 @@ typedef struct VirtMachine {
+@@ -206,6 +210,13 @@ typedef struct VirtMachine {
      uint64_t maxinsns;
      uint64_t trace;
  
 +    const char *   vm_stf_trace = nullptr; //stf file
-+    bool           vm_stf_trace_enabled; 
++    bool           vm_stf_trace_enabled;
 +    bool           vm_no_stf_priv_check; //disable privilege checks in trace generation
 +    uint64_t       vm_stf_prog_asid;
 +    uint64_t       vm_stf_count;
@@ -219,7 +231,7 @@ index c13239a..0cb0754 100644
  FILE *simpoint_bb_file = nullptr;
  int   simpoint_roi     = 0;  // start without ROI enabled
 diff --git a/src/dromajo_cosim.cpp b/src/dromajo_cosim.cpp
-index 24faded..2ae8bbf 100644
+index 24faded..7e09fcb 100644
 --- a/src/dromajo_cosim.cpp
 +++ b/src/dromajo_cosim.cpp
 @@ -27,6 +27,11 @@
@@ -229,7 +241,7 @@ index 24faded..2ae8bbf 100644
 +//STF: cosim shares riscv_cpu_interp, dromajo_template.h
 +#include "stf-inc/stf_writer.hpp"
 +#include "stf-inc/stf_record_types.hpp"
-+stf::STFWriter stf_writer; 
++stf::STFWriter stf_writer;
 +
  #ifdef GOLDMEM_INORDER
  void check_inorder_load(int cid, uint64_t addr, uint8_t sz, uint64_t ld_data, bool io_map);

--- a/traces/stf_trace_gen/dromajo_stf_lib.patch
+++ b/traces/stf_trace_gen/dromajo_stf_lib.patch
@@ -47,7 +47,7 @@ index a3f932a..a955816 100644
      include_directories(/usr/local/include /usr/local/include/libelf /opt/homebrew/include /opt/homebrew/include/libelf)
      target_link_libraries(dromajo_cosim -L/usr/local/lib -L/opt/homebrew/lib -lelf)
 diff --git a/include/dromajo_template.h b/include/dromajo_template.h
-index 2d8e9cc..a0a4bab 100644
+index 2d8e9cc..df8b09d 100644
 --- a/include/dromajo_template.h
 +++ b/include/dromajo_template.h
 @@ -52,6 +52,13 @@
@@ -72,96 +72,94 @@ index 2d8e9cc..a0a4bab 100644
      n_cycles++;
      /* Note: we assume NULL is represented as a zero number */
      code_ptr          = NULL;
-@@ -1807,6 +1815,92 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
+@@ -1807,6 +1815,90 @@ int no_inline glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) {
          }
          /* update PC for next instruction */
      jump_insn:;
 +
++        if(s->machine->common.vm_stf_trace) { //if cmd line specifies tracing
 +
-+        // HERE HERE stf trace support
-+      if(s->machine->common.vm_stf_trace) { //if cmd line specifies tracing
++            int hartid = s->mhartid; //FIXME
++            RISCVCPUState *cpu = s->machine->cpu_state[hartid];
 +
-+        int hartid = 0; //FIXME
-+        RISCVCPUState *cpu = s->machine->cpu_state[hartid];
++            bool isStart = insn == START_TRACE_OPC;
++            bool isStop  = insn == STOP_TRACE_OPC;
 +
-+        bool isStart = insn == START_TRACE_OPC;
-+        bool isStop  = insn == STOP_TRACE_OPC;
++            if(isStart) {
++                s->machine->common.vm_stf_trace_enabled = true;
++                fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Started at 0x%lx\n", GET_PC());
 +
-+        if(isStart) {
-+          s->machine->common.vm_stf_trace_enabled = true;
-+          fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Started at 0x%lx\n", GET_PC());
++                s->machine->common.vm_stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;
 +
-+          s->machine->common.vm_stf_prog_asid = (cpu->satp >> 4) & 0xFFFF;
++                if((bool)stf_writer == false) {
++                    stf_writer.open(s->machine->common.vm_stf_trace);
++                    stf_writer.addTraceInfo(stf::TraceInfoRecord(
++                               stf::STF_GEN::STF_GEN_DROMAJO, 1, 1, 0,"Trace from Dromajo"));
++                    stf_writer.setISA(stf::ISA::RISCV);
++                    stf_writer.setHeaderIEM(stf::INST_IEM::STF_INST_IEM_RV64);
++                    stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_RV64);
++                    stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PHYSICAL_ADDRESS);
++                    stf_writer.setHeaderPC(GET_PC());
++                    stf_writer.finalizeHeader();
++                }
++            } else if(isStop) {
 +
-+          if((bool)stf_writer == false) {
-+            stf_writer.open(s->machine->common.vm_stf_trace);
-+            stf_writer.addTraceInfo(stf::TraceInfoRecord(
-+                       stf::STF_GEN::STF_GEN_DROMAJO, 1, 1, 0,"Trace from Dromajo"));
-+            stf_writer.setISA(stf::ISA::RISCV);
-+            stf_writer.setHeaderIEM(stf::INST_IEM::STF_INST_IEM_RV64);
-+            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_RV64);
-+            stf_writer.setTraceFeature(stf::TRACE_FEATURES::STF_CONTAIN_PHYSICAL_ADDRESS);
-+            stf_writer.setHeaderPC(GET_PC());
-+            stf_writer.finalizeHeader();
-+          }
-+        } else if(isStop) {
-+          s->machine->common.vm_stf_trace_enabled = false;
-+          fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Stopped at 0x%lx\n", GET_PC());
-+          fprintf(dromajo_stderr, ">>> DROMAJO: Traced %ld insts\n",
-+                                   s->machine->common.vm_stf_count);
-+          stf_writer.close();
-+        }
-+
-+        if(!isStart && s->machine->common.vm_stf_trace_enabled) {
-+
-+          //int priv = riscv_get_priv_level(cpu);
-+          uint32_t insn_raw = insn;
-+          uint64_t last_pc  = virt_machine_get_pc(s->machine, hartid);
-+
-+          if(s->machine->common.vm_no_stf_priv_check
-+             || ((s->priv == 0)
-+                 && (cpu->pending_exception == -1)
-+                 && (s->machine->common.vm_stf_prog_asid == ((cpu->satp >> 4) & 0xFFFF))))
-+          {
-+            ++s->machine->common.vm_stf_count;
-+            const uint32_t inst_width = ((insn_raw & 0x3) == 0x3) ? 4 : 2;
-+            bool skip_record = false;
-+            if(cpu->info != ctf_nop) {
-+              stf_writer << stf::InstPCTargetRecord(GET_PC());
-+            } else {
-+
-+              if(GET_PC() != last_pc + inst_width) {
-+                  skip_record = true;
-+              }
++                s->machine->common.vm_stf_trace_enabled = false;
++                fprintf(dromajo_stderr, ">>> DROMAJO: Tracing Stopped at 0x%lx\n", GET_PC());
++                fprintf(dromajo_stderr, ">>> DROMAJO: Traced %ld insts\n",
++                                         s->machine->common.vm_stf_count);
++                stf_writer.close();
 +            }
 +
-+            if(false == skip_record)
-+            {
-+              // If the last instruction were a load/store,
-+              // record the last vaddr, size, and if it were a
-+              // read or write.
-+              if(cpu->last_data_vaddr
-+                   != std::numeric_limits<decltype(cpu->last_data_vaddr)>::max())
-+              {
-+                  stf_writer << stf::InstMemAccessRecord(cpu->last_data_vaddr,
-+                                                         cpu->last_data_size,
-+                                                         0,
-+                                                         (cpu->last_data_type == 0) ?
-+                                                         stf::INST_MEM_ACCESS::READ :
-+                                                         stf::INST_MEM_ACCESS::WRITE);
-+                  stf_writer << stf::InstMemContentRecord(0); // empty content for now
-+              }
++            if(!isStart && s->machine->common.vm_stf_trace_enabled) {
 +
-+              if(inst_width == 4) {
-+                  stf_writer << stf::InstOpcode32Record(insn_raw);
-+              }
-+              else {
-+                  stf_writer << stf::InstOpcode16Record(insn_raw & 0xFFFF);
-+              }
++                uint32_t insn_raw = insn;
++                uint64_t last_pc  = virt_machine_get_pc(s->machine, hartid);
++
++                if(s->machine->common.vm_no_stf_priv_check
++                   || ((s->priv == 0)
++                       && (cpu->pending_exception == -1)
++                       && (s->machine->common.vm_stf_prog_asid == ((cpu->satp >> 4) & 0xFFFF))))
++                {
++                    ++s->machine->common.vm_stf_count;
++                    const uint32_t inst_width = ((insn_raw & 0x3) == 0x3) ? 4 : 2;
++                    bool skip_record = false;
++                    if(cpu->info != ctf_nop) {
++                        stf_writer << stf::InstPCTargetRecord(GET_PC());
++                    } else {
++
++                      if(GET_PC() != last_pc + inst_width) {
++                          skip_record = true;
++                      }
++                    }
++
++                    if(false == skip_record)
++                    {
++                        // If the last instruction were a load/store,
++                        // record the last vaddr, size, and if it were a
++                        // read or write.
++                        if(cpu->last_data_vaddr
++                            != std::numeric_limits<decltype(cpu->last_data_vaddr)>::max())
++                        {
++                            stf_writer << stf::InstMemAccessRecord(cpu->last_data_vaddr,
++                                                                   cpu->last_data_size,
++                                                                   0,
++                                                                   (cpu->last_data_type == 0) ?
++                                                                   stf::INST_MEM_ACCESS::READ :
++                                                                   stf::INST_MEM_ACCESS::WRITE);
++                            stf_writer << stf::InstMemContentRecord(0); // empty content for now
++                        }
++
++                        if(inst_width == 4) {
++                            stf_writer << stf::InstOpcode32Record(insn_raw);
++                        }
++                        else {
++                            stf_writer << stf::InstOpcode16Record(insn_raw & 0xFFFF);
++                        }
++                    }
++                }
 +            }
-+          }
 +        }
-+      }
      } /* end of main loop */
  illegal_insn:
      s->pending_exception = CAUSE_ILLEGAL_INSTRUCTION;


### PR DESCRIPTION
This branch uses latest dromajo f3c3112, the changes move stf start/stop macro detection and trace generation into include/dromajo_template.h, within glue(riscv_cpu_interp, XLEN)(RISCVCPUState *s, int n_cycles) 

I have done limited testing with dhrystone and coremark, single cpu, with zstf and stf. 
stf_diff reports no differences. (clarify: no differences between this and stf's generated by previous impl.)

The main loop body can exit w/ a goto, illegal_instructions/etc. 
The tracing code makes the assumption that exceptions are not traced. 
I'm looking at this more. 

other minor changes:
- moved some globals into a struct, stf_writer remains global
- I've added a switch --no_stf_priv_check which can disable that check in the tracing enabled loop
- added tohost/fromhost  (clarify: struct variables added only, in advance of support)