### PR TITLE
Ignore Renaming of x0

### DIFF
--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -40,7 +40,7 @@ namespace olympia
                 uint32_t val = 0;
                 core_types::RegFile rf = core_types::RegFile::RF_INVALID;
                 mavis::InstMetaData::OperandFieldID field_id = mavis::InstMetaData::OperandFieldID::NONE;
-                bool x0 = false;
+                bool is_x0 = false;
             };
             using RegList = std::vector<Reg>;
 

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -40,6 +40,7 @@ namespace olympia
                 uint32_t val = 0;
                 core_types::RegFile rf = core_types::RegFile::RF_INVALID;
                 mavis::InstMetaData::OperandFieldID field_id = mavis::InstMetaData::OperandFieldID::NONE;
+                bool x0 = false;
             };
             using RegList = std::vector<Reg>;
 

--- a/core/LSU.cpp
+++ b/core/LSU.cpp
@@ -140,15 +140,18 @@ namespace olympia
             if (inst_ptr->isStoreInst()) {
                 const auto rf = inst_ptr->getRenameData().getDataReg().rf;
                 const auto &data_bits = inst_ptr->getDataRegisterBitMask(rf);
-
-                if (!scoreboard_views_[rf]->isSet(data_bits)) {
-                    all_ready = false;
-                    scoreboard_views_[rf]->registerReadyCallback(data_bits, inst_ptr->getUniqueID(),
-                                                                [this, inst_ptr](const sparta::Scoreboard::RegisterBitMask &)
-                                                                {
-                                                                    this->getInstsFromDispatch_(inst_ptr);
-                                                                });
-                    ILOG("Instruction NOT ready: " << inst_ptr << " Bits needed:" << sparta::printBitSet(data_bits));
+                
+                // if x0 is a data operand, we don't need to check scoreboard
+                if (!inst_ptr->getRenameData().getDataReg().is_x0){
+                    if (!scoreboard_views_[rf]->isSet(data_bits)) {
+                        all_ready = false;
+                        scoreboard_views_[rf]->registerReadyCallback(data_bits, inst_ptr->getUniqueID(),
+                                                                    [this, inst_ptr](const sparta::Scoreboard::RegisterBitMask &)
+                                                                    {
+                                                                        this->getInstsFromDispatch_(inst_ptr);
+                                                                    });
+                        ILOG("Instruction NOT ready: " << inst_ptr << " Bits needed:" << sparta::printBitSet(data_bits));
+                    }
                 }
             }
         }

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -137,9 +137,8 @@ namespace olympia
             const auto dest = dests[0];
             const auto rf  = olympia::coreutils::determineRegisterFile(dest);
             const auto num = dest.field_value;
-            const bool is_x0 = num == 0 && rf == core_types::RF_INTEGER;
-            if (false == is_x0)
-            if (is_x0)
+            const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
+            if (!is_x0)
             {
                 auto const & original_dest = inst_ptr->getRenameData().getOriginalDestination();
                 --reference_counter_[original_dest.rf][original_dest.val];

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -137,7 +137,8 @@ namespace olympia
             const auto dest = dests[0];
             const auto rf  = olympia::coreutils::determineRegisterFile(dest);
             const auto num = dest.field_value;
-            const bool is_x0 = num != 0 || rf != core_types::RF_INTEGER;
+            const bool is_x0 = num == 0 && rf == core_types::RF_INTEGER;
+            if (false == is_x0)
             if (is_x0)
             {
                 auto const & original_dest = inst_ptr->getRenameData().getOriginalDestination();

--- a/test/core/rename/Rename_test.cpp
+++ b/test/core/rename/Rename_test.cpp
@@ -43,15 +43,15 @@ class olympia::RenameTester
 public:
     void test_clearing_rename_structures(olympia::Rename & rename){
         // after all instructions have retired, we should have:
-        // num_rename_registers - 32 registers = freelist size
-        // because we initialize the first 32 registers
+        // num_rename_registers - 31 registers = freelist size
+        // because we initialize the first 31 registers (x1-x31) for integer
         if (rename.reference_counter_[0].size() == 34){
-            EXPECT_TRUE(rename.freelist_[0].size() == 2);
+            EXPECT_TRUE(rename.freelist_[0].size() == 3);
             // in the case of only two free PRFs, they should NOT be equal to each other
             EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
         }
         else{
-            EXPECT_TRUE(rename.freelist_[0].size() == 96);
+            EXPECT_TRUE(rename.freelist_[0].size() == 97);
         }
         // we're only expecting one reference
         EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
@@ -63,7 +63,7 @@ public:
         // num_rename_registers - 32 registers = freelist size
         // because we initialize the first 32 registers
         if (rename.reference_counter_[0].size() == 34){
-            EXPECT_TRUE(rename.freelist_[0].size() == 2);
+            EXPECT_TRUE(rename.freelist_[0].size() == 3);
             // in the case of only two free PRFs, they should NOT be equal to each other
             EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
         }
@@ -71,17 +71,17 @@ public:
             EXPECT_TRUE(rename.freelist_[0].size() == 96);
         }
         // we're only expecting one reference
-        EXPECT_TRUE(rename.reference_counter_[0][1] == 0);
+        EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
         EXPECT_TRUE(rename.reference_counter_[0][2] == 0);
 
     }
     void test_one_instruction(olympia::Rename & rename){
         // process only one instruction, check that freelist and map_tables are allocated correctly
         if (rename.reference_counter_[0].size() == 34){
-            EXPECT_TRUE(rename.freelist_[0].size() == 1);
+            EXPECT_TRUE(rename.freelist_[0].size() == 2);
         }
         else{
-            EXPECT_TRUE(rename.freelist_[0].size() == 95);
+            EXPECT_TRUE(rename.freelist_[0].size() == 96);
         }
         // map table entry is valid, as it's been allocated
 
@@ -100,10 +100,10 @@ public:
         // num_rename_registers - 32 registers = freelist size
         // because we initialize the first 32 registers
         if (rename.reference_counter_[0].size() == 34){
-            EXPECT_TRUE(rename.freelist_[0].size() == 2);
+            EXPECT_TRUE(rename.freelist_[0].size() == 3);
         }
         else{
-            EXPECT_TRUE(rename.freelist_[0].size() == 96);
+            EXPECT_TRUE(rename.freelist_[0].size() == 97);
         }
         // we're only expecting a value of 1 for registers x0 -> x31 because we initialize them
         EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
@@ -118,7 +118,7 @@ public:
     void test_float(olympia::Rename & rename){
         // ensure the correct register file is used
         EXPECT_TRUE(rename.freelist_[1].size() == 94);
-        EXPECT_TRUE(rename.freelist_[0].size() == 96);
+        EXPECT_TRUE(rename.freelist_[0].size() == 97);
     }
 };
 

--- a/test/core/rename/expected_output/big_core.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Aug 16 09:17:28 2023
-#Elapsed:  0.006601s
+#Start:    Monday Mon Nov 13 13:38:20 2023
+#Elapsed:  0.018322s
 {0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: alu0 got 10 credits, total: 10
@@ -75,7 +75,7 @@
 {0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid: 0    RENAMED 0 pid: 1 'add	3,1,2' 
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -84,9 +84,9 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 0 DISPATCHED 0 pid: 1 'add	3,1,2'  to alu0
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid: 1    RENAMED 0 pid: 2 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [2,32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(1)  PID(2)  add
@@ -99,7 +99,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.rename info} getAckFromROB_: Retired instruction: uid: 0    RETIRED 0 pid: 1 'add	3,1,2' 
@@ -112,9 +112,9 @@
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11'  to alu0
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub
 {0000000005 00000005 top.rename info} getAckFromROB_: Retired instruction: uid: 1    RETIRED 0 pid: 2 'add	4,3,2' 
@@ -127,9 +127,9 @@
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12'  to alu0
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32-33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [0,32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 1
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(5)  PID(6)  lw
 {0000000006 00000006 top.rename info} getAckFromROB_: Retired instruction: uid: 2    RETIRED 0 pid: 3 'mul	13,12,11' 
@@ -142,9 +142,9 @@
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3'  to alu0
 {0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
 {0000000006 00000006 top.decode info} inCredits: Got credits from dut: 1
 {0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(6)  PID(7)  sw
 {0000000007 00000007 top.rename info} getAckFromROB_: Retired instruction: uid: 3    RETIRED 0 pid: 4 'sub	14,13,12' 
@@ -157,7 +157,7 @@
 {0000000007 00000007 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3'  to lsu
 {0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid: 6    RENAMED 0 pid: 7 'sw	3' 
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
+{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
 {0000000007 00000007 top.decode info} inCredits: Got credits from dut: 1
 {0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(7)  PID(8)  div
 {0000000008 00000008 top.rename info} getAckFromROB_: Retired instruction: uid: 4    RETIRED 0 pid: 5 'sub	5,4,3' 
@@ -172,7 +172,7 @@
 {0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10] for 'integer' scoreboard
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10,15] for 'integer' scoreboard
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
 {0000000008 00000008 top.decode info} inCredits: Got credits from dut: 1
 {0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(8)  PID(9)  fadd.s
 {0000000009 00000009 top.rename info} getAckFromROB_: Retired instruction: uid: 5    RETIRED 0 pid: 6 'lw	5,4,3' 

--- a/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Aug 16 09:17:37 2023
-#Elapsed:  0.00388s
+#Start:    Monday Mon Nov 13 13:41:47 2023
+#Elapsed:  0.021868s
 {0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: alu0 got 10 credits, total: 10
@@ -75,7 +75,7 @@
 {0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid: 0    RENAMED 0 pid: 1 'add	3,1,2' 
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -84,9 +84,9 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 0 DISPATCHED 0 pid: 1 'add	3,1,2'  to alu0
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid: 1    RENAMED 0 pid: 2 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [2,32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(1)  PID(2)  add
@@ -95,126 +95,122 @@
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
 {0000000003 00000003 top.dispatch info} acceptInst: alu0: dispatching uid: 1    RENAMED 0 pid: 2 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 1 DISPATCHED 0 pid: 2 'add	4,3,2'  to alu0
-{0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NO_RENAMES
+{0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
+{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
+{0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.rename info} getAckFromROB_: Retired instruction: uid: 0    RETIRED 0 pid: 1 'add	3,1,2' 
+{0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.alu0 info} sinkInst_: Instruction: 'uid: 1 DISPATCHED 0 pid: 2 'add	4,3,2' ' sinked
 {0000000004 00000004 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 1 DISPATCHED 0 pid: 2 'add	4,3,2' ' sinked
 {0000000004 00000004 top.dispatch info} receiveCredits_: alu0 got 2 credits, total: 10
-{0000000004 00000004 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000004 00000004 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
+{0000000004 00000004 top.dispatch info} acceptInst: alu0: dispatching uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
+{0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11'  to alu0
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
 {0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [3] for 'integer' scoreboard
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
-{0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
+{0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub
 {0000000005 00000005 top.rename info} getAckFromROB_: Retired instruction: uid: 1    RETIRED 0 pid: 2 'add	4,3,2' 
-{0000000005 00000005 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
-{0000000005 00000005 top.dispatch info} receiveCredits_: alu0 got 0 credits, total: 10
+{0000000005 00000005 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(3)  PID(4)  sub
+{0000000005 00000005 top.alu0 info} sinkInst_: Instruction: 'uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11' ' sinked
+{0000000005 00000005 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11' ' sinked
+{0000000005 00000005 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000005 00000005 top.dispatch info} acceptInst: alu0: dispatching uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
-{0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11'  to alu0
+{0000000005 00000005 top.dispatch info} acceptInst: alu0: dispatching uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
+{0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12'  to alu0
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [3] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [3,12] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [0,32] for 'integer' scoreboard
 {0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [4] for 'integer' scoreboard
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 1
-{0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub
-{0000000006 00000006 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(3)  PID(4)  sub
-{0000000006 00000006 top.alu0 info} sinkInst_: Instruction: 'uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11' ' sinked
-{0000000006 00000006 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11' ' sinked
+{0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(5)  PID(6)  lw
+{0000000006 00000006 top.rename info} getAckFromROB_: Retired instruction: uid: 2    RETIRED 0 pid: 3 'mul	13,12,11' 
+{0000000006 00000006 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(4)  PID(5)  sub
+{0000000006 00000006 top.alu0 info} sinkInst_: Instruction: 'uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12' ' sinked
+{0000000006 00000006 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12' ' sinked
+{0000000006 00000006 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000006 00000006 top.dispatch info} acceptInst: alu0: dispatching uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
-{0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12'  to alu0
-{0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NO_RENAMES
-{0000000007 00000007 top.rename info} getAckFromROB_: Retired instruction: uid: 2    RETIRED 0 pid: 3 'mul	13,12,11' 
-{0000000007 00000007 top.alu0 info} sinkInst_: Instruction: 'uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12' ' sinked
-{0000000007 00000007 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12' ' sinked
-{0000000007 00000007 top.dispatch info} receiveCredits_: alu0 got 2 credits, total: 10
-{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000006 00000006 top.dispatch info} acceptInst: alu0: dispatching uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
+{0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3'  to alu0
+{0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
+{0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [13] for 'integer' scoreboard
+{0000000006 00000006 top.decode info} inCredits: Got credits from dut: 1
+{0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(6)  PID(7)  sw
+{0000000007 00000007 top.rename info} getAckFromROB_: Retired instruction: uid: 3    RETIRED 0 pid: 4 'sub	14,13,12' 
+{0000000007 00000007 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(5)  PID(6)  lw
+{0000000007 00000007 top.alu0 info} sinkInst_: Instruction: 'uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3' ' sinked
+{0000000007 00000007 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3' ' sinked
+{0000000007 00000007 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
+{0000000007 00000007 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
+{0000000007 00000007 top.dispatch info} acceptInst: lsu: dispatching uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
+{0000000007 00000007 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3'  to lsu
 {0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup source register bit mask [32-33] for 'integer' scoreboard
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup destination register bit mask [13] for 'integer' scoreboard
+{0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid: 6    RENAMED 0 pid: 7 'sw	3' 
+{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
 {0000000007 00000007 top.decode info} inCredits: Got credits from dut: 1
-{0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(5)  PID(6)  lw
-{0000000008 00000008 top.rename info} getAckFromROB_: Retired instruction: uid: 3    RETIRED 0 pid: 4 'sub	14,13,12' 
-{0000000008 00000008 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(4)  PID(5)  sub
+{0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(7)  PID(8)  div
+{0000000008 00000008 top.rename info} getAckFromROB_: Retired instruction: uid: 4    RETIRED 0 pid: 5 'sub	5,4,3' 
+{0000000008 00000008 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(6)  PID(7)  sw
+{0000000008 00000008 top.lsu info} sinkInst_: Instruction: 'uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3' ' sinked
+{0000000008 00000008 top.lsu info} sinkRetireInst_: Instruction: 'uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3' ' sinked
 {0000000008 00000008 top.dispatch info} receiveCredits_: alu0 got 0 credits, total: 10
 {0000000008 00000008 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000008 00000008 top.dispatch info} acceptInst: alu0: dispatching uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
-{0000000008 00000008 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3'  to alu0
+{0000000008 00000008 top.dispatch info} acceptInst: lsu: dispatching uid: 6    RENAMED 0 pid: 7 'sw	3' 
+{0000000008 00000008 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 6 DISPATCHED 0 pid: 7 'sw	3'  to lsu
 {0000000008 00000008 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
+{0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10,15] for 'integer' scoreboard
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [14] for 'integer' scoreboard
 {0000000008 00000008 top.decode info} inCredits: Got credits from dut: 1
-{0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(6)  PID(7)  sw
-{0000000009 00000009 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(5)  PID(6)  lw
-{0000000009 00000009 top.alu0 info} sinkInst_: Instruction: 'uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3' ' sinked
-{0000000009 00000009 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3' ' sinked
+{0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(8)  PID(9)  fadd.s
+{0000000009 00000009 top.rename info} getAckFromROB_: Retired instruction: uid: 5    RETIRED 0 pid: 6 'lw	5,4,3' 
+{0000000009 00000009 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(7)  PID(8)  div
+{0000000009 00000009 top.lsu info} sinkInst_: Instruction: 'uid: 6 DISPATCHED 0 pid: 7 'sw	3' ' sinked
+{0000000009 00000009 top.lsu info} sinkRetireInst_: Instruction: 'uid: 6 DISPATCHED 0 pid: 7 'sw	3' ' sinked
+{0000000009 00000009 top.dispatch info} receiveCredits_: lsu got 2 credits, total: 10
 {0000000009 00000009 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000009 00000009 top.dispatch info} acceptInst: lsu: dispatching uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
-{0000000009 00000009 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3'  to lsu
+{0000000009 00000009 top.dispatch info} acceptInst: alu0: dispatching uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
+{0000000009 00000009 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15'  to alu0
 {0000000009 00000009 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000009 00000009 top.rename info} renameInstructions_: sending inst to dispatch: uid: 6    RENAMED 0 pid: 7 'sw	3' 
-{0000000009 00000009 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
+{0000000009 00000009 top.rename info} renameInstructions_: sending inst to dispatch: uid: 8    RENAMED 0 pid: 9 'fadd.s	' 
 {0000000009 00000009 top.decode info} inCredits: Got credits from dut: 1
-{0000000009 00000009 top.decode info} Sending group: 0x00000000 UID(7)  PID(8)  div
-{0000000010 00000010 top.rename info} getAckFromROB_: Retired instruction: uid: 4    RETIRED 0 pid: 5 'sub	5,4,3' 
-{0000000010 00000010 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(6)  PID(7)  sw
-{0000000010 00000010 top.lsu info} sinkInst_: Instruction: 'uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3' ' sinked
-{0000000010 00000010 top.lsu info} sinkRetireInst_: Instruction: 'uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3' ' sinked
-{0000000010 00000010 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
+{0000000009 00000009 top.decode info} Sending group: 0x00000000 UID(9)  PID(10)  beq
+{0000000010 00000010 top.rename info} getAckFromROB_: Retired instruction: uid: 6    RETIRED 0 pid: 7 'sw	3' 
+{0000000010 00000010 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(8)  PID(9)  fadd.s
+{0000000010 00000010 top.alu0 info} sinkInst_: Instruction: 'uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15' ' sinked
+{0000000010 00000010 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15' ' sinked
+{0000000010 00000010 top.dispatch info} receiveCredits_: lsu got 0 credits, total: 10
 {0000000010 00000010 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000010 00000010 top.dispatch info} acceptInst: lsu: dispatching uid: 6    RENAMED 0 pid: 7 'sw	3' 
-{0000000010 00000010 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 6 DISPATCHED 0 pid: 7 'sw	3'  to lsu
+{0000000010 00000010 top.dispatch info} acceptInst: fpu0: dispatching uid: 8    RENAMED 0 pid: 9 'fadd.s	' 
+{0000000010 00000010 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 8 DISPATCHED 0 pid: 9 'fadd.s	'  to fpu0
 {0000000010 00000010 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000010 00000010 top.rename info} renameInstructions_: sending inst to dispatch: uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup source register bit mask [10] for 'integer' scoreboard
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup source register bit mask [10,15] for 'integer' scoreboard
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup destination register bit mask [5] for 'integer' scoreboard
+{0000000010 00000010 top.rename info} renameInstructions_: sending inst to dispatch: uid: 9    RENAMED 0 pid: 10 'beq	' 
 {0000000010 00000010 top.decode info} inCredits: Got credits from dut: 1
-{0000000010 00000010 top.decode info} Sending group: 0x00000000 UID(8)  PID(9)  fadd.s
-{0000000011 00000011 top.rename info} getAckFromROB_: Retired instruction: uid: 5    RETIRED 0 pid: 6 'lw	5,4,3' 
-{0000000011 00000011 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(7)  PID(8)  div
-{0000000011 00000011 top.lsu info} sinkInst_: Instruction: 'uid: 6 DISPATCHED 0 pid: 7 'sw	3' ' sinked
-{0000000011 00000011 top.lsu info} sinkRetireInst_: Instruction: 'uid: 6 DISPATCHED 0 pid: 7 'sw	3' ' sinked
-{0000000011 00000011 top.dispatch info} receiveCredits_: lsu got 2 credits, total: 10
+{0000000011 00000011 top.rename info} getAckFromROB_: Retired instruction: uid: 7    RETIRED 0 pid: 8 'div	20,10,15' 
+{0000000011 00000011 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(9)  PID(10)  beq
+{0000000011 00000011 top.fpu0 info} sinkInst_: Instruction: 'uid: 8 DISPATCHED 0 pid: 9 'fadd.s	' ' sinked
+{0000000011 00000011 top.fpu0 info} sinkRetireInst_: Instruction: 'uid: 8 DISPATCHED 0 pid: 9 'fadd.s	' ' sinked
+{0000000011 00000011 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
 {0000000011 00000011 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000011 00000011 top.dispatch info} acceptInst: alu0: dispatching uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
-{0000000011 00000011 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15'  to alu0
-{0000000011 00000011 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000011 00000011 top.rename info} renameInstructions_: sending inst to dispatch: uid: 8    RENAMED 0 pid: 9 'fadd.s	' 
-{0000000011 00000011 top.decode info} inCredits: Got credits from dut: 1
-{0000000011 00000011 top.decode info} Sending group: 0x00000000 UID(9)  PID(10)  beq
-{0000000012 00000012 top.rename info} getAckFromROB_: Retired instruction: uid: 6    RETIRED 0 pid: 7 'sw	3' 
-{0000000012 00000012 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(8)  PID(9)  fadd.s
-{0000000012 00000012 top.alu0 info} sinkInst_: Instruction: 'uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15' ' sinked
-{0000000012 00000012 top.alu0 info} sinkRetireInst_: Instruction: 'uid: 7 DISPATCHED 0 pid: 8 'div	20,10,15' ' sinked
-{0000000012 00000012 top.dispatch info} receiveCredits_: lsu got 0 credits, total: 10
-{0000000012 00000012 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000012 00000012 top.dispatch info} acceptInst: fpu0: dispatching uid: 8    RENAMED 0 pid: 9 'fadd.s	' 
-{0000000012 00000012 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 8 DISPATCHED 0 pid: 9 'fadd.s	'  to fpu0
-{0000000012 00000012 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000012 00000012 top.rename info} renameInstructions_: sending inst to dispatch: uid: 9    RENAMED 0 pid: 10 'beq	' 
-{0000000012 00000012 top.decode info} inCredits: Got credits from dut: 1
-{0000000013 00000013 top.rename info} getAckFromROB_: Retired instruction: uid: 7    RETIRED 0 pid: 8 'div	20,10,15' 
-{0000000013 00000013 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(9)  PID(10)  beq
-{0000000013 00000013 top.fpu0 info} sinkInst_: Instruction: 'uid: 8 DISPATCHED 0 pid: 9 'fadd.s	' ' sinked
-{0000000013 00000013 top.fpu0 info} sinkRetireInst_: Instruction: 'uid: 8 DISPATCHED 0 pid: 9 'fadd.s	' ' sinked
-{0000000013 00000013 top.dispatch info} receiveCredits_: alu0 got 1 credits, total: 10
-{0000000013 00000013 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000013 00000013 top.dispatch info} acceptInst: br0: dispatching uid: 9    RENAMED 0 pid: 10 'beq	' 
-{0000000013 00000013 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 9 DISPATCHED 0 pid: 10 'beq	'  to br0
-{0000000014 00000014 top.rename info} getAckFromROB_: Retired instruction: uid: 8    RETIRED 0 pid: 9 'fadd.s	' 
-{0000000014 00000014 top.br0 info} sinkInst_: Instruction: 'uid: 9 DISPATCHED 0 pid: 10 'beq	' ' sinked
-{0000000014 00000014 top.br0 info} sinkRetireInst_: Instruction: 'uid: 9 DISPATCHED 0 pid: 10 'beq	' ' sinked
-{0000000014 00000014 top.dispatch info} receiveCredits_: fpu0 got 1 credits, total: 10
-{0000000014 00000014 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
-{0000000015 00000015 top.rename info} getAckFromROB_: Retired instruction: uid: 9    RETIRED 0 pid: 10 'beq	' 
-{0000000015 00000015 top.dispatch info} receiveCredits_: br0 got 1 credits, total: 10
-{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000011 00000011 top.dispatch info} acceptInst: br0: dispatching uid: 9    RENAMED 0 pid: 10 'beq	' 
+{0000000011 00000011 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 9 DISPATCHED 0 pid: 10 'beq	'  to br0
+{0000000012 00000012 top.rename info} getAckFromROB_: Retired instruction: uid: 8    RETIRED 0 pid: 9 'fadd.s	' 
+{0000000012 00000012 top.br0 info} sinkInst_: Instruction: 'uid: 9 DISPATCHED 0 pid: 10 'beq	' ' sinked
+{0000000012 00000012 top.br0 info} sinkRetireInst_: Instruction: 'uid: 9 DISPATCHED 0 pid: 10 'beq	' ' sinked
+{0000000012 00000012 top.dispatch info} receiveCredits_: fpu0 got 1 credits, total: 10
+{0000000012 00000012 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000013 00000013 top.rename info} getAckFromROB_: Retired instruction: uid: 9    RETIRED 0 pid: 10 'beq	' 
+{0000000013 00000013 top.dispatch info} receiveCredits_: br0 got 1 credits, total: 10
+{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process

--- a/test/core/rename/expected_output/medium_core.out.EXPECTED
+++ b/test/core/rename/expected_output/medium_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Aug 16 09:17:34 2023
-#Elapsed:  0.003144s
+#Start:    Monday Mon Nov 13 13:41:06 2023
+#Elapsed:  0.010183s
 {0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: alu0 got 10 credits, total: 10
@@ -27,7 +27,7 @@
 {0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid: 0    RENAMED 0 pid: 1 'add	3,1,2' 
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -36,9 +36,9 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 0 DISPATCHED 0 pid: 1 'add	3,1,2'  to alu0
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid: 1    RENAMED 0 pid: 2 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [2,32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(1)  PID(2)  add
@@ -51,7 +51,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.rename info} getAckFromROB_: Retired instruction: uid: 0    RETIRED 0 pid: 1 'add	3,1,2' 
@@ -64,9 +64,9 @@
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11'  to alu0
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub
 {0000000005 00000005 top.rename info} getAckFromROB_: Retired instruction: uid: 1    RETIRED 0 pid: 2 'add	4,3,2' 
@@ -79,9 +79,9 @@
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12'  to alu0
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32-33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [0,32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 1
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(5)  PID(6)  lw
 {0000000006 00000006 top.rename info} getAckFromROB_: Retired instruction: uid: 2    RETIRED 0 pid: 3 'mul	13,12,11' 
@@ -94,9 +94,9 @@
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3'  to alu0
 {0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
 {0000000006 00000006 top.decode info} inCredits: Got credits from dut: 1
 {0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(6)  PID(7)  sw
 {0000000007 00000007 top.rename info} getAckFromROB_: Retired instruction: uid: 3    RETIRED 0 pid: 4 'sub	14,13,12' 
@@ -109,7 +109,7 @@
 {0000000007 00000007 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3'  to lsu
 {0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid: 6    RENAMED 0 pid: 7 'sw	3' 
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
+{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
 {0000000007 00000007 top.decode info} inCredits: Got credits from dut: 1
 {0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(7)  PID(8)  div
 {0000000008 00000008 top.rename info} getAckFromROB_: Retired instruction: uid: 4    RETIRED 0 pid: 5 'sub	5,4,3' 
@@ -124,7 +124,7 @@
 {0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10] for 'integer' scoreboard
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10,15] for 'integer' scoreboard
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
 {0000000008 00000008 top.decode info} inCredits: Got credits from dut: 1
 {0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(8)  PID(9)  fadd.s
 {0000000009 00000009 top.rename info} getAckFromROB_: Retired instruction: uid: 5    RETIRED 0 pid: 6 'lw	5,4,3' 

--- a/test/core/rename/expected_output/small_core.out.EXPECTED
+++ b/test/core/rename/expected_output/small_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Monday Mon Nov 13 13:41:29 2023
-#Elapsed:  0.016553s
+#Start:    Thursday Thu Nov 16 20:04:48 2023
+#Elapsed:  0.00973s
 {0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: alu0 got 10 credits, total: 10

--- a/test/core/rename/expected_output/small_core.out.EXPECTED
+++ b/test/core/rename/expected_output/small_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Aug 16 09:17:32 2023
-#Elapsed:  0.004099s
+#Start:    Monday Mon Nov 13 13:41:29 2023
+#Elapsed:  0.016553s
 {0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: alu0 got 10 credits, total: 10
@@ -21,7 +21,7 @@
 {0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid: 0    RENAMED 0 pid: 1 'add	3,1,2' 
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
 {0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -30,9 +30,9 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 0 DISPATCHED 0 pid: 1 'add	3,1,2'  to alu0
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid: 1    RENAMED 0 pid: 2 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [2,32] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(1)  PID(2)  add
@@ -45,7 +45,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid: 2    RENAMED 0 pid: 3 'mul	13,12,11' 
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
 {0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.rename info} getAckFromROB_: Retired instruction: uid: 0    RETIRED 0 pid: 1 'add	3,1,2' 
@@ -58,9 +58,9 @@
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 2 DISPATCHED 0 pid: 3 'mul	13,12,11'  to alu0
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid: 3    RENAMED 0 pid: 4 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,34] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub
 {0000000005 00000005 top.rename info} getAckFromROB_: Retired instruction: uid: 1    RETIRED 0 pid: 2 'add	4,3,2' 
@@ -73,9 +73,9 @@
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 3 DISPATCHED 0 pid: 4 'sub	14,13,12'  to alu0
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid: 4    RENAMED 0 pid: 5 'sub	5,4,3' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32-33] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [0,32] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 1
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(5)  PID(6)  lw
 {0000000006 00000006 top.rename info} getAckFromROB_: Retired instruction: uid: 2    RETIRED 0 pid: 3 'mul	13,12,11' 
@@ -88,9 +88,9 @@
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 4 DISPATCHED 0 pid: 5 'sub	5,4,3'  to alu0
 {0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid: 5    RENAMED 0 pid: 6 'lw	5,4,3' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
 {0000000006 00000006 top.decode info} inCredits: Got credits from dut: 1
 {0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(6)  PID(7)  sw
 {0000000007 00000007 top.rename info} getAckFromROB_: Retired instruction: uid: 3    RETIRED 0 pid: 4 'sub	14,13,12' 
@@ -103,7 +103,7 @@
 {0000000007 00000007 top.dispatch info} dispatchInstructions_: Sending instruction: uid: 5 DISPATCHED 0 pid: 6 'lw	5,4,3'  to lsu
 {0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
 {0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid: 6    RENAMED 0 pid: 7 'sw	3' 
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [32] for 'integer' scoreboard
+{0000000007 00000007 top.rename info} renameInstructions_: 	setup store data register bit mask [0] for 'integer' scoreboard
 {0000000007 00000007 top.decode info} inCredits: Got credits from dut: 1
 {0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(7)  PID(8)  div
 {0000000008 00000008 top.rename info} getAckFromROB_: Retired instruction: uid: 4    RETIRED 0 pid: 5 'sub	5,4,3' 
@@ -118,7 +118,7 @@
 {0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid: 7    RENAMED 0 pid: 8 'div	20,10,15' 
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10] for 'integer' scoreboard
 {0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [10,15] for 'integer' scoreboard
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
 {0000000008 00000008 top.decode info} inCredits: Got credits from dut: 1
 {0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(8)  PID(9)  fadd.s
 {0000000009 00000009 top.rename info} getAckFromROB_: Retired instruction: uid: 5    RETIRED 0 pid: 6 'lw	5,4,3' 


### PR DESCRIPTION
Fix renaming to skip renaming of x0 outlined in https://github.com/riscv-software-src/riscv-perf-model/issues/118.

Changes:
- `renameInstructions_()` now checks if a source is x0, if it is and is a data operand for a LSU operation, we still create a data register for it, as we need to check in LSU for x0 before issuing instruction
- Added a boolean `x0` field to `Reg` struct in `RenameData` that tracks if a data register is an `x0` instruction. This helps on reclamation of rename credits in `getAckFromROB_()` to make sure we don't decrement for an x0 data register
- Updated logic to handle for destination reclamation in `getAckFromROB_()` to ensure when we reclaim credits/freelist registers/references, we don't process them for x0 destinations
- Fixed initial allocation of freelist registers for `RF_INTEGER` to only map registers for x1 - x31, before we were mapping from x0 - x31, so we should technically see a performance improvement as we gained 1 extra freelist register from not renaming x0