### PR TITLE
Initial implementation of branch prediction using a BTB

### DIFF
--- a/core/BTB.hpp
+++ b/core/BTB.hpp
@@ -1,0 +1,277 @@
+#pragma once
+
+#include "sparta/simulation/Unit.hpp"
+#include "sparta/simulation/TreeNode.hpp"
+#include "sparta/simulation/ParameterSet.hpp"
+
+#include "sparta/utils/MathUtils.hpp"
+
+#include "cache/TreePLRUReplacement.hpp"
+#include "cache/BasicCacheItem.hpp"
+#include "cache/Cache.hpp"
+#include "cache/BasicCacheSet.hpp"
+
+#include "MiscUtils.hpp"
+
+
+namespace olympia
+{
+
+    /**
+     * @file   BTB.hpp
+     * @brief The Branch Target Buffer -- Cache like structure for branch instructions
+     *
+     * Based on SimpleCache, this unit defines a way associate cache like structure
+     * designed to be used as a way of steering fetch ahead.
+     *
+     * Each set covers an entire block of memory, there may be multiple branches with
+     * the same block address. We use a full tag to hit on the right line.
+     *
+     * We store the branch PC, target, type and a 2 bit saturating counter to predict
+     * direction on conditional branches.
+     */
+
+    class BTBEntry : public sparta::cache::BasicCacheItem
+    {
+    public:
+
+        enum class BranchType : std::uint16_t {
+            CONDITIONAL,
+            __FIRST = CONDITIONAL,
+            DIRECT,
+            INDIRECT,
+            RETURN,
+            __LAST
+        };
+
+        BTBEntry() :
+            valid_(false)
+        { };
+
+        BTBEntry(const BTBEntry &rhs) :
+            BasicCacheItem(rhs),
+            valid_(rhs.valid_),
+            target_(rhs.target_),
+            is_call_(rhs.is_call_),
+            branchtype_(rhs.branchtype_),
+            lhist_counter_(rhs.lhist_counter_)
+        { };
+
+        BTBEntry &operator=(const BTBEntry &rhs)
+        {
+            if (&rhs != this) {
+                BasicCacheItem::operator=(rhs);
+                valid_ = rhs.valid_;
+                target_ = rhs.target_;
+                is_call_ = rhs.is_call_;
+                branchtype_ = rhs.branchtype_;
+                lhist_counter_ = rhs.lhist_counter_;
+            }
+            return *this;
+        }
+
+        void reset(uint64_t addr)
+        {
+            setValid(true);
+            setAddr(addr);
+            resetLHistCounter_();
+        }
+
+        void setValid(bool v) { valid_ = v; }
+        bool isValid() const { return valid_; }
+
+        void setTarget(uint64_t t) { target_ = t; }
+        uint64_t getTarget() const { return target_; }
+
+        void setBranchType(BranchType branchtype, bool is_call = false)
+        {
+            sparta_assert(!is_call ||
+                          miscutils::isOneOf(branchtype, BranchType::INDIRECT,
+                                                         BranchType::DIRECT,
+                                                         BranchType::RETURN),
+                          "Invalid branch and call combination");
+            branchtype_ = branchtype;
+            is_call_ = is_call;
+        }
+
+        BranchType getBranchType() const { return branchtype_; }
+        bool isCall() const { return is_call_; }
+
+        bool predictDirection() {
+            if (branchtype_ == BranchType::CONDITIONAL)
+            {
+                return lhist_counter_ >= 0;
+            }
+            return true;
+        }
+
+        void updateDirection(bool taken)
+        {
+            if (taken)
+            {
+                lhist_counter_ = std::min(lhist_count_max_, ++lhist_counter_);
+            }
+            else
+            {
+                lhist_counter_ = std::max(lhist_count_min_, --lhist_counter_);
+            }
+        }
+
+
+    private:
+        bool                 valid_ = false;
+        uint64_t             target_;
+        bool                 is_call_ = false;
+        BranchType           branchtype_;
+        int32_t              lhist_counter_ = 0;
+        static constexpr int32_t lhist_count_max_ = 1; // 2 bit saturating counter.
+        static constexpr int32_t lhist_count_min_ = -2;
+
+        void resetLHistCounter_() { lhist_counter_ = 0; }
+
+    };
+
+
+    class BTBAddrDecoder : public sparta::cache::AddrDecoderIF
+    {
+    public:
+        BTBAddrDecoder(uint32_t entries, uint32_t stride, uint32_t num_ways)
+        {
+            index_mask_ = (entries/num_ways)-1;
+            index_shift_ = sparta::utils::floor_log2(stride);
+        }
+        virtual uint64_t calcTag(uint64_t addr) const { return addr; }
+        virtual uint32_t calcIdx(uint64_t addr) const { return (addr >> index_shift_) & index_mask_; }
+        virtual uint64_t calcBlockAddr(uint64_t addr) const { return addr; }
+        virtual uint64_t calcBlockOffset(uint64_t addr) const { return 0;}
+    private:
+        uint32_t index_mask_;
+        uint32_t index_shift_;
+    };
+
+    class BTB : public sparta::Unit
+    {
+    public:
+        static constexpr const char * name = "btb";
+
+        // Parameters
+        //! \brief Parameters for BTB
+        class BTBParameterSet : public sparta::ParameterSet
+        {
+        public:
+            BTBParameterSet(sparta::TreeNode* n) :
+                sparta::ParameterSet(n)
+            {}
+
+            PARAMETER(uint64_t, num_of_entries, 4096, "BTB # of entries (power of 2)")
+            PARAMETER(uint32_t, block_size, 64, "BTB Search stride in bytes (power of 2)")
+            PARAMETER(uint32_t, associativity, 8, "BTB associativity (power of 2)")
+        };
+
+
+        BTB(sparta::TreeNode * node, const BTBParameterSet *p) : sparta::Unit(node)
+        {
+            cache_.reset(new sparta::cache::Cache(p->num_of_entries,
+                                                  1,
+                                                  p->block_size,
+                                                  BTBEntry(),
+                                                  sparta::cache::TreePLRUReplacement(p->associativity),
+                                                  false));
+            cache_->setAddrDecoder(new BTBAddrDecoder(p->num_of_entries, p->block_size, p->associativity));
+        }
+
+        /**
+         *\return whether an addr is in the cache
+            */
+        bool isHit(uint64_t addr) const
+        {
+            const BTBEntry *line = cache_->peekItem(addr);
+            return ( line != nullptr );
+        }
+
+        // Get a line for replacement
+        BTBEntry &getLineForReplacementWithInvalidCheck(uint64_t addr)
+        {
+            return cache_->getCacheSet(addr).getItemForReplacementWithInvalidCheck();
+        }
+
+        /**
+         *\return Pointer to line with addr.  nullptr is returned if not fould
+        */
+        BTBEntry * getLine(uint64_t addr)
+        {
+            return cache_->getItem(addr);
+        }
+
+        /**
+         *\return Pointer to line with addr.  nullptr is returned if not fould
+        */
+        const BTBEntry * peekLine(uint64_t addr) const
+        {
+            return cache_->peekItem(addr);
+        }
+
+        void touchLRU(const BTBEntry &line)
+        {
+            auto *rep = cache_->getCacheSetAtIndex( line.getSetIndex() ).getReplacementIF();
+            rep->touchLRU( line.getWay() );
+        }
+
+        void touchMRU(const BTBEntry &line)
+        {
+            auto *rep = cache_->getCacheSetAtIndex( line.getSetIndex() ).getReplacementIF();
+            rep->touchMRU( line.getWay() );
+        }
+
+        // Allocate 'line' as having the new 'addr'
+        // 'line' doesn't know anything about NT
+        void allocateWithMRUUpdate(BTBEntry &line,
+                                    uint64_t   addr)
+        {
+            line.reset( addr );
+            touchMRU( line );
+        }
+
+
+        void invalidateLineWithLRUUpdate(BTBEntry &line)
+        {
+            static const uint64_t addr=0;
+            line.reset( addr );
+            line.setValid( false );
+            touchLRU( line );
+        }
+
+        void invalidateAll()
+        {
+            auto set_it = cache_->begin();
+            for (; set_it != cache_->end(); ++set_it) {
+                auto line_it = set_it->begin();
+                for (; line_it != set_it->end(); ++line_it) {
+                    line_it->setValid(false);
+                }
+                set_it->getReplacementIF()->reset();
+
+            }
+        }
+
+        /**
+         * determine if there are any open ways in the set.
+         */
+        bool hasOpenWay(const uint64_t addr)
+        {
+            return cache_->getCacheSet(addr).hasOpenWay();
+        }
+
+        uint32_t getNumWays() const {
+            return cache_->getNumWays();
+        }
+
+        uint32_t getNumSets() const {
+            return cache_->getNumSets();
+        }
+
+
+    private:
+        std::unique_ptr<sparta::cache::Cache<BTBEntry>> cache_;
+    };
+};

--- a/core/CPUFactories.hpp
+++ b/core/CPUFactories.hpp
@@ -38,8 +38,7 @@ namespace olympia{
                                 olympia::Core::CoreParameterSet> core_rf;
 
         //! \brief Resouce Factory to build a Fetch Unit
-        sparta::ResourceFactory<olympia::Fetch,
-                                olympia::Fetch::FetchParameterSet> fetch_rf;
+        FetchFactory fetch_rf;
 
         //! \brief Resouce Factory to build a Decode Unit
         sparta::ResourceFactory<olympia::Decode,

--- a/core/CPUTopology.cpp
+++ b/core/CPUTopology.cpp
@@ -162,6 +162,10 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.rename.ports.out_uop_queue_credits"
         },
         {
+            "cpu.core*.decode.ports.out_decode_flush",
+            "cpu.core*.flushmanager.ports.in_decode_flush"
+        },
+        {
             "cpu.core*.rename.ports.out_dispatch_queue_write",
             "cpu.core*.dispatch.ports.in_dispatch_queue_write"
         },
@@ -250,11 +254,19 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.rename.ports.in_rename_retire_ack"
         },
         {
+            "cpu.core*.rob.ports.out_rob_retire_ack_rename",
+            "cpu.core*.fetch.ports.in_rob_retire_ack"
+        },
+        {
             "cpu.core*.flushmanager.ports.out_retire_flush",
             "cpu.core*.dispatch.ports.in_reorder_flush"
         },
         {
             "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.decode.ports.in_reorder_flush"
+        },
+        {
+            "cpu.core*.flushmanager.ports.out_decode_flush",
             "cpu.core*.decode.ports.in_reorder_flush"
         },
         {

--- a/core/CPUTopology.cpp
+++ b/core/CPUTopology.cpp
@@ -182,11 +182,11 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.lsu.ports.out_lsu_credits"
         },
         {
-            "cpu.core*.dispatch.ports.out_reorder_buffer_write",
+            "cpu.core*.rename.ports.out_reorder_buffer_write",
             "cpu.core*.rob.ports.in_reorder_buffer_write"
         },
         {
-            "cpu.core*.dispatch.ports.in_reorder_buffer_credits",
+            "cpu.core*.rename.ports.in_reorder_buffer_credits",
             "cpu.core*.rob.ports.out_reorder_buffer_credits"
         },
         {
@@ -242,10 +242,6 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.flushmanager.ports.in_retire_flush"
         },
         {
-            "cpu.core*.rob.ports.out_fetch_flush_redirect",
-            "cpu.core*.flushmanager.ports.in_fetch_flush_redirect"
-        },
-        {
             "cpu.core*.rob.ports.out_rob_retire_ack",
             "cpu.core*.lsu.ports.in_rob_retire_ack"
         },
@@ -282,7 +278,11 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.lsu.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_fetch_flush_redirect",
+            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.fetch.ports.in_fetch_flush_redirect"
+        },
+        {
+            "cpu.core*.flushmanager.ports.out_decode_flush",
             "cpu.core*.fetch.ports.in_fetch_flush_redirect"
         }
     };

--- a/core/CPUTopology.cpp
+++ b/core/CPUTopology.cpp
@@ -163,7 +163,7 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
         },
         {
             "cpu.core*.decode.ports.out_decode_flush",
-            "cpu.core*.flushmanager.ports.in_decode_flush"
+            "cpu.core*.flushmanager.ports.in_flush_request"
         },
         {
             "cpu.core*.rename.ports.out_dispatch_queue_write",
@@ -239,7 +239,7 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
         },
         {
             "cpu.core*.rob.ports.out_retire_flush",
-            "cpu.core*.flushmanager.ports.in_retire_flush"
+            "cpu.core*.flushmanager.ports.in_flush_request"
         },
         {
             "cpu.core*.rob.ports.out_rob_retire_ack",
@@ -254,35 +254,35 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.fetch.ports.in_rob_retire_ack"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.dispatch.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.decode.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_decode_flush",
+            "cpu.core*.flushmanager.ports.out_flush_lower",
             "cpu.core*.decode.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.rename.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.rob.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.lsu.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.fetch.ports.in_fetch_flush_redirect"
         },
         {
-            "cpu.core*.flushmanager.ports.out_decode_flush",
+            "cpu.core*.flushmanager.ports.out_flush_lower",
             "cpu.core*.fetch.ports.in_fetch_flush_redirect"
         }
     };
@@ -332,8 +332,14 @@ void olympia::CoreTopologySimple::bindTree(sparta::RootTreeNode* root_node)
                 // Bind flushing
                 const std::string exe_flush_in =
                     core_node + ".execute." +  unit_name + ".ports.in_reorder_flush";;
-                const std::string flush_manager = flushmanager_ports + ".out_retire_flush";
+                const std::string flush_manager = flushmanager_ports + ".out_flush_upper";
                 bind_ports(exe_flush_in, flush_manager);
+
+                // Bind flush requests
+                const std::string exe_flush_out =
+                    core_node + ".execute." +  unit_name + ".ports.out_execute_flush";;
+                const std::string flush_manager_in = flushmanager_ports + ".in_flush_request";
+                bind_ports(exe_flush_out, flush_manager_in);
             }
         }
     }

--- a/core/Decode.cpp
+++ b/core/Decode.cpp
@@ -90,7 +90,7 @@ namespace olympia
                 {
                     if (inst->isCondBranch())
                     {
-                        ILOG("BTB miss on conditional branch, predicting 'not-taken'");
+                        ILOG("BTB miss on conditional branch, predicting 'not-taken': " << inst);
                         inst->setBranchMispredict(inst->isTakenBranch());
                     }
                     else

--- a/core/Decode.cpp
+++ b/core/Decode.cpp
@@ -96,7 +96,8 @@ namespace olympia
                     else
                     {
                         ILOG("Decode flush required - requesting flush!");
-                        out_decode_flush_.send(inst);
+                        FlushManager::FlushingCriteria criteria(FlushManager::FlushEvent::MISFETCH, inst);
+                        out_decode_flush_.send(criteria);
                         break;
                     }
                 }

--- a/core/Decode.hpp
+++ b/core/Decode.hpp
@@ -65,9 +65,13 @@ namespace olympia
         sparta::DataOutPort<InstGroupPtr> uop_queue_outp_      {&unit_port_set_, "out_uop_queue_write"};
         sparta::DataInPort<uint32_t>      uop_queue_credits_in_{&unit_port_set_, "in_uop_queue_credits", sparta::SchedulingPhase::Tick, 0};
 
+        // Flush required after decode
+        sparta::DataOutPort<InstPtr>      out_decode_flush_    {&unit_port_set_, "out_decode_flush"};
+
         // For flush
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_
              {&unit_port_set_, "in_reorder_flush", sparta::SchedulingPhase::Flush, 1};
+
 
         // The decode instruction event
         sparta::UniqueEvent<> ev_decode_insts_event_  {&unit_event_set_, "decode_insts_event", CREATE_SPARTA_HANDLER(Decode, decodeInsts_)};
@@ -79,6 +83,7 @@ namespace olympia
         void receiveUopQueueCredits_(const uint32_t &);
         void decodeInsts_();
         void handleFlush_(const FlushManager::FlushingCriteria & criteria);
+        void handleFetchFlush_(const InstPtr &);
 
         uint32_t uop_queue_credits_ = 0;
         const uint32_t num_to_decode_;

--- a/core/Decode.hpp
+++ b/core/Decode.hpp
@@ -66,7 +66,7 @@ namespace olympia
         sparta::DataInPort<uint32_t>      uop_queue_credits_in_{&unit_port_set_, "in_uop_queue_credits", sparta::SchedulingPhase::Tick, 0};
 
         // Flush required after decode
-        sparta::DataOutPort<InstPtr>      out_decode_flush_    {&unit_port_set_, "out_decode_flush"};
+        sparta::DataOutPort<FlushManager::FlushingCriteria>  out_decode_flush_    {&unit_port_set_, "out_decode_flush"};
 
         // For flush
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_

--- a/core/ExecutePipe.cpp
+++ b/core/ExecutePipe.cpp
@@ -178,6 +178,15 @@ namespace olympia
             scoreboard_views_[reg_file_]->setReady(dest_bits);
         }
 
+        // Deal with mispredicted branches
+        if (ex_inst->isBranch() && ex_inst->isBranchMispredict())
+        {
+            ILOG("mispredicted branch " << ex_inst <<
+                  " was actually " << (ex_inst->isTakenBranch() ? "taken" : "not-taken"));
+            FlushManager::FlushingCriteria criteria(FlushManager::FlushEvent::MISPREDICTION, ex_inst);
+            out_execute_flush_.send(criteria);
+        }
+
         // We're not busy anymore
         unit_busy_ = false;
 

--- a/core/ExecutePipe.hpp
+++ b/core/ExecutePipe.hpp
@@ -71,6 +71,8 @@ namespace olympia
         sparta::DataOutPort<uint32_t> out_scheduler_credits_{&unit_port_set_, "out_scheduler_credits"};
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_
             {&unit_port_set_, "in_reorder_flush", sparta::SchedulingPhase::Flush, 1};
+        sparta::DataOutPort<FlushManager::FlushingCriteria> out_execute_flush_
+            {&unit_port_set_, "out_execute_flush"};
 
         // Ready queue
         typedef std::list<InstPtr> ReadyQueue;

--- a/core/ExecutePipe.hpp
+++ b/core/ExecutePipe.hpp
@@ -75,6 +75,7 @@ namespace olympia
         // Ready queue
         typedef std::list<InstPtr> ReadyQueue;
         ReadyQueue  ready_queue_;
+        ReadyQueue  issue_queue_;
 
         // Scoreboards
         using ScoreboardViews = std::array<std::unique_ptr<sparta::ScoreboardView>, core_types::N_REGFILES>;
@@ -119,11 +120,23 @@ namespace olympia
         void issueInst_();
         void getInstsFromDispatch_(const InstPtr&);
 
+        // Insert instructions into ready_queue
+        void scheduleInst_(const InstPtr&);
+
         // Used to complete the inst in the FPU
         void completeInst_(const InstPtr&);
 
         // Used to flush the ALU
-        void flushInst_(const FlushManager::FlushingCriteria & criteria);
+        void flushInst_(const FlushManager::FlushingCriteria &);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Regular Function/Subroutine Call
+
+        // Append new instruction into issue queue
+        void appendIssueQueue_(const InstPtr &);
+
+        // Pop completed instruction out of issue queue
+        void popIssueQueue_(const InstPtr &);
 
         // Friend class used in rename testing
         friend class ExecutePipeTester;

--- a/core/Fetch.cpp
+++ b/core/Fetch.cpp
@@ -32,7 +32,9 @@ namespace olympia
         // Schedule a single event to start reading from a trace file
         sparta::StartupEvent(node, CREATE_SPARTA_HANDLER(Fetch, initialize_));
 
-        in_fetch_flush_redirect_.registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(Fetch, flushFetch_, uint64_t));
+        in_fetch_flush_redirect_.registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(Fetch, flushFetch_, InstPtr));
+
+        in_rob_retire_ack_.registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(Fetch, getAckFromROB_, InstPtr));
 
     }
 
@@ -48,7 +50,47 @@ namespace olympia
                                                          workload->getValueAsString(),
                                                          skip_nonuser_mode_);
 
+        // Setup BTB
+        btb_ = getContainer()->getChild("btb")->getResourceAs<olympia::BTB>();
+
         fetch_inst_event_->schedule(1);
+    }
+
+
+    bool Fetch::predictInstruction_(InstPtr inst)
+    {
+        if (btb_->isHit(inst->getPC()))
+        {
+            btb_hits_++;
+
+            inst->setBTBHit(true);
+
+            auto btb_entry = btb_->getLine(inst->getPC());
+            btb_->touchMRU(*btb_entry);
+
+            auto predicted_taken = btb_entry->predictDirection();
+            inst->setBranchMispredict(predicted_taken != inst->isTakenBranch());
+
+            // TODO Compare targets (RAS/Indirect mispredicitons)
+            // TODO Consider BTB hit aliasing..
+
+            ILOG("BTB Hit on " << inst << " predicted " << (predicted_taken ? "taken" : "not-taken"));
+
+            return predicted_taken;
+        }
+        return false;
+    }
+
+    void Fetch::getAckFromROB_(const InstPtr & inst)
+    {
+        // If we've mispredicted the branch, then the flush should have happened already
+        // so the branch should have been inserted in the BTB already. Just update the direction
+        // counter.
+        if (inst->isBranch() && inst->isCondBranch() && btb_->isHit(inst->getPC()))
+        {
+            auto btb_entry = btb_->getLine(inst->getPC());
+            btb_entry->updateDirection(inst->isTakenBranch());
+        }
     }
 
     void Fetch::fetchInstruction_()
@@ -62,16 +104,22 @@ namespace olympia
         for(uint32_t i = 0; i < upper; ++i)
         {
             InstPtr ex_inst = inst_generator_->getNextInst(my_clk_);
-            if(SPARTA_EXPECT_TRUE(nullptr != ex_inst))
+            if(SPARTA_EXPECT_FALSE(nullptr == ex_inst))
             {
-                ex_inst->setSpeculative(speculative_path_);
-                insts_to_send->emplace_back(ex_inst);
-
-                ILOG("Sending: " << ex_inst << " down the pipe");
-            }
-            else {
                 break;
             }
+
+            ex_inst->setSpeculative(speculative_path_);
+            insts_to_send->emplace_back(ex_inst);
+
+            ILOG("Sending: " << ex_inst << " down the pipe");
+
+            if (predictInstruction_(ex_inst))
+            {
+                ILOG("Redirection predicted, ending fetch group")
+                break;
+            }
+
         }
 
         if(false == insts_to_send->empty())
@@ -105,16 +153,62 @@ namespace olympia
         fetch_inst_event_->schedule(sparta::Clock::Cycle(0));
     }
 
-    // Called from Retire via in_fetch_flush_redirect_ port
-    void Fetch::flushFetch_(const uint64_t & new_addr) {
-        ILOG("Fetch: receive flush on new_addr=0x"
-             << std::hex << new_addr << std::dec);
+    // Could be a flush from decode, or retirement
+    // Decode flush -> BTB miss
+    // Retire flush -> Mispredicted branch (and potentially a BTB miss)
+    void Fetch::flushFetch_(const InstPtr & flush_inst)
+    {
+        ILOG("Fetch: receive flush " << flush_inst);
+
+        // Insert BTB misses on flush
+        auto pc = flush_inst->getPC();
+        if (flush_inst->isBranch() && !btb_->isHit(pc))
+        {
+            auto entry = &btb_->getLineForReplacementWithInvalidCheck(pc);
+            entry->reset(pc);
+            entry->setTarget(flush_inst->getTargetVAddr());
+            if (flush_inst->isCondBranch())
+            {
+                entry->setBranchType(BTBEntry::BranchType::CONDITIONAL);
+            }
+            else
+            {
+                entry->setBranchType(BTBEntry::BranchType::DIRECT);
+            }
+            btb_->touchMRU(*entry);
+            btb_misses_++;
+        }
+
+        // Rewind the tracefile
+        if (flush_inst->getStatus() == Inst::Status::COMPLETED || flush_inst->getStatus() == Inst::Status::RETIRED)
+        {
+            inst_generator_->reset(flush_inst, true); // Skip to next instruction
+        }
+        else
+        {
+            inst_generator_->reset(flush_inst, false); // Replay this instruction
+        }
 
         // Cancel all previously sent instructions on the outport
         out_fetch_queue_write_.cancel();
 
         // No longer speculative
-        speculative_path_ = false;
+        // speculative_path_ = false;
+    }
+
+
+    void FetchFactory::onConfiguring(sparta::ResourceTreeNode* node)
+    {
+        btb_tn_.reset(new sparta::ResourceTreeNode(node,
+                                                   "btb",
+                                                   sparta::TreeNode::GROUP_NAME_NONE,
+                                                   sparta::TreeNode::GROUP_IDX_NONE,
+                                                   "Branch Target Buffer",
+                                                   &btb_fact_));
+    }
+
+    void FetchFactory::deleteSubtree(sparta::ResourceTreeNode*) {
+        btb_tn_.reset();
     }
 
 }

--- a/core/Fetch.hpp
+++ b/core/Fetch.hpp
@@ -22,6 +22,7 @@
 #include "CoreTypes.hpp"
 #include "InstGroup.hpp"
 #include "BTB.hpp"
+#include "FlushManager.hpp"
 
 namespace olympia
 {
@@ -88,7 +89,7 @@ namespace olympia
             {&unit_port_set_, "in_fetch_queue_credits", sparta::SchedulingPhase::Tick, 0};
 
         // Incoming flush from Retire w/ redirect
-        sparta::DataInPort<InstPtr> in_fetch_flush_redirect_
+        sparta::DataInPort<FlushManager::FlushingCriteria> in_fetch_flush_redirect_
             {&unit_port_set_, "in_fetch_flush_redirect", sparta::SchedulingPhase::Flush, 1};
 
         // Retired Instruction
@@ -145,7 +146,7 @@ namespace olympia
         void fetchInstruction_();
 
         // Receive flush from retire
-        void flushFetch_(const InstPtr &);
+        void flushFetch_(const FlushManager::FlushingCriteria &);
 
         void getAckFromROB_(const InstPtr &);
 

--- a/core/Fetch.hpp
+++ b/core/Fetch.hpp
@@ -145,11 +145,11 @@ namespace olympia
         void fetchInstruction_();
 
         // Receive flush from retire
-        void flushFetch_(const InstPtr & flush_inst);
+        void flushFetch_(const InstPtr &);
 
         void getAckFromROB_(const InstPtr &);
 
-        bool predictInstruction_(InstPtr inst);
+        bool predictInstruction_(const InstPtr &);
 
         // Are we fetching a speculative path?
         bool speculative_path_ = false;

--- a/core/FlushManager.hpp
+++ b/core/FlushManager.hpp
@@ -41,7 +41,60 @@ namespace olympia
     class FlushManager : public sparta::Unit
     {
     public:
-        typedef uint64_t FlushingCriteria;
+
+        enum class FlushEvent : std::uint16_t {
+            TRAP = 0,
+            __FIRST = TRAP,
+            MISPREDICTION,
+            TARGET_MISPREDICTION,
+            MISFETCH,
+            POST_SYNC,
+            __LAST
+        };
+
+        class FlushingCriteria
+        {
+        public:
+            FlushingCriteria(FlushEvent cause, InstPtr inst_ptr) :
+                cause_(cause),
+                inst_ptr_(inst_ptr) {}
+
+            FlushingCriteria() = default;
+            FlushingCriteria(const FlushingCriteria &rhs) = default;
+            FlushingCriteria &operator=(const FlushingCriteria &rhs) = default;
+
+            FlushEvent getCause() const        { return cause_; } // TODO FlushEvent -> FlushCause
+            const InstPtr & getInstPtr() const { return inst_ptr_; }
+
+            bool isInclusiveFlush() const
+            {
+                static const std::map<FlushEvent, bool> inclusive_flush_map = {
+                    {FlushEvent::TRAP,                 true},
+                    {FlushEvent::MISFETCH,             true},
+                    {FlushEvent::MISPREDICTION,        false},
+                    {FlushEvent::TARGET_MISPREDICTION, false},
+                    {FlushEvent::POST_SYNC,            false}
+                };
+                if(auto match = inclusive_flush_map.find(cause_); match != inclusive_flush_map.end()) {
+                    return match->second;
+                }
+                sparta_assert(false, "Unknown flush cause: " << static_cast<uint16_t>(cause_));
+                return true;
+            }
+
+            bool flush(const InstPtr& other) const
+            {
+                return isInclusiveFlush() ?
+                    inst_ptr_->getUniqueID() <= other->getUniqueID() :
+                    inst_ptr_->getUniqueID() < other->getUniqueID();
+            }
+
+        private:
+            FlushEvent cause_;
+            InstPtr inst_ptr_;
+        };
+
+
         static constexpr char name[] = "flushmanager";
 
         class FlushManagerParameters : public sparta::ParameterSet
@@ -62,24 +115,21 @@ namespace olympia
             Unit(rc, name),
             out_retire_flush_(getPortSet(), "out_retire_flush", false),
             in_retire_flush_(getPortSet(), "in_retire_flush", 0),
-            out_fetch_flush_redirect_(getPortSet(), "out_fetch_flush_redirect", false),
-            in_fetch_flush_redirect_(getPortSet(), "in_fetch_flush_redirect", 0),
             in_decode_flush_(getPortSet(), "in_decode_flush", 0),
             out_decode_flush_(getPortSet(), "out_decode_flush", false)
         {
             (void)params;
             in_retire_flush_.
                 registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(FlushManager,
-                                                                      forwardRetireFlush_,
+                                                                      receiveFlush_,
                                                                       FlushingCriteria));
-            in_fetch_flush_redirect_.
-                registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(FlushManager,
-                                                                      forwardFetchRedirectFlush_,
-                                                                      InstPtr));
             in_decode_flush_.
                 registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(FlushManager,
-                                                                        forwardDecodeFlush_,
-                                                                        InstPtr));
+                                                                        receiveFlush_,
+                                                                        FlushingCriteria));
+
+            in_retire_flush_.registerConsumerEvent(ev_flush_);
+            in_decode_flush_.registerConsumerEvent(ev_flush_);
         }
 
     private:
@@ -88,28 +138,65 @@ namespace olympia
         sparta::DataOutPort<FlushingCriteria> out_retire_flush_;
         sparta::DataInPort <FlushingCriteria> in_retire_flush_;
 
-        // Flush redirect for Fetch
-        sparta::DataOutPort<InstPtr> out_fetch_flush_redirect_;
-        sparta::DataInPort <InstPtr> in_fetch_flush_redirect_;
-
         // Decode Flush Port
-        sparta::DataInPort<InstPtr> in_decode_flush_;
+        sparta::DataInPort<FlushingCriteria> in_decode_flush_;
         sparta::DataOutPort<FlushingCriteria> out_decode_flush_;
 
-        // Internal method used to forward the flush to the attached
-        // listeners
-        void forwardRetireFlush_(const FlushingCriteria & flush_data) {
-            out_retire_flush_.send(flush_data);
+        sparta::UniqueEvent<> ev_flush_ {&unit_event_set_,
+                                        "flush_event",
+                                         CREATE_SPARTA_HANDLER(FlushManager, forwardFlush_)};
+
+        // Arbitrates and forwards the flush request from the input flush ports, to the output ports
+        void forwardFlush_()
+        {
+            if (in_retire_flush_.dataReceivedThisCycle())
+            {
+                auto flush_data = in_retire_flush_.pullData();
+                out_retire_flush_.send(flush_data);
+                ILOG("forwarding retirement flush request: " << flush_data);
+            }
+            else
+            {
+                sparta_assert(in_decode_flush_.dataReceivedThisCycle(), "flush event scheduled for no reason?");
+                auto flush_data = in_decode_flush_.pullData();
+                out_decode_flush_.send(flush_data);
+                ILOG("forwarding decode flush request: " << flush_data);
+            }
         }
 
-        // Internal method used to forward the fetch redirect
-        void forwardFetchRedirectFlush_(const InstPtr & flush_data) {
-            out_fetch_flush_redirect_.send(flush_data);
+        void receiveFlush_(const FlushingCriteria &)
+        {
+            ev_flush_.schedule();
         }
 
-        void forwardDecodeFlush_(const InstPtr & flush_data) {
-            out_fetch_flush_redirect_.send(flush_data);
-            out_decode_flush_.send(flush_data->getUniqueID());
-        }
     };
+
+
+    inline std::ostream & operator<<(std::ostream & os, const FlushManager::FlushEvent & event) {
+        switch(event) {
+            case FlushManager::FlushEvent::TRAP:
+                os << "TRAP";
+                break;
+            case FlushManager::FlushEvent::MISPREDICTION:
+                os << "MISPREDICTION";
+                break;
+            case FlushManager::FlushEvent::TARGET_MISPREDICTION:
+                os << "TARGET_MISPREDICTION";
+                break;
+            case FlushManager::FlushEvent::MISFETCH:
+                os << "MISFETCH";
+                break;
+            case FlushManager::FlushEvent::POST_SYNC:
+                os << "POST_SYNC";
+                break;
+            case FlushManager::FlushEvent::__LAST:
+                throw sparta::SpartaException("__LAST cannot be a valid enum event state.");
+        }
+        return os;
+    }
+
+    inline std::ostream & operator<<(std::ostream & os, const FlushManager::FlushingCriteria & criteria) {
+        os << criteria.getInstPtr() << " " << criteria.getCause();
+        return os;
+    }
 }

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -48,6 +48,9 @@ namespace olympia
             void setOriginalDestination(const Reg & destination){
                 original_dest_ = destination;
             }
+            void setDestination(const Reg & destination){
+                dest_ = destination;
+            }
             void setDataReg(const Reg & data_reg){
                 data_reg_ = data_reg;
             }
@@ -60,11 +63,15 @@ namespace olympia
             const Reg & getOriginalDestination() const {
                 return original_dest_;
             }
+            const Reg & getDestination() const {
+                return dest_;
+            }
             const Reg & getDataReg() const {
                 return data_reg_;
             }
         private:
             Reg original_dest_;
+            Reg dest_;
             RegList src_;
             Reg data_reg_;
         };
@@ -86,6 +93,7 @@ namespace olympia
             SCHEDULED,
             COMPLETED,
             RETIRED,
+            FLUSHED,
             __LAST
         };
 
@@ -112,6 +120,10 @@ namespace olympia
 
         bool getCompletedStatus() const {
             return getStatus() == olympia::Inst::Status::COMPLETED;
+        }
+
+        bool getFlushedStatus() const {
+            return getStatus() == olympia::Inst::Status::FLUSHED;
         }
 
         void setStatus(Status status) {
@@ -285,6 +297,9 @@ namespace olympia
                 break;
             case Inst::Status::RETIRED:
                 os << "RETIRED";
+                break;
+            case Inst::Status::FLUSHED:
+                os << "FLUSHED";
                 break;
             case Inst::Status::__LAST:
                 throw sparta::SpartaException("__LAST cannot be a valid enum state.");

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -52,6 +52,10 @@ namespace olympia
         return (curr_inst_index_ == n_insts_);
     }
 
+    void JSONInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
+    {
+    }
+
     InstPtr JSONInstGenerator::getNextInst(const sparta::Clock * clk)
     {
         if(SPARTA_EXPECT_FALSE(isDone())) {
@@ -149,6 +153,18 @@ namespace olympia
     bool TraceInstGenerator::isDone() const {
         return next_it_ == reader_->end();
     }
+
+    void TraceInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
+    {
+        next_it_ = inst_ptr->getSTFIterator();
+        program_id_ = inst_ptr->getProgramID();
+        if (skip)
+        {
+            ++next_it_;
+            ++program_id_;
+        }
+    }
+
     InstPtr TraceInstGenerator::getNextInst(const sparta::Clock * clk)
     {
         if(SPARTA_EXPECT_FALSE(isDone())) {
@@ -161,7 +177,8 @@ namespace olympia
             InstPtr inst = mavis_facade_->makeInst(opcode, clk);
             inst->setPC(next_it_->pc());
             inst->setUniqueID(++unique_id_);
-            inst->setProgramID(unique_id_);
+            inst->setProgramID(program_id_++);
+            inst->setSTFIterator(next_it_);
             if (const auto& mem_accesses = next_it_->getMemoryAccesses(); !mem_accesses.empty())
             {
                 using VectorAddrType = std::vector<sparta::memory::addr_t>;
@@ -174,6 +191,11 @@ namespace olympia
                 inst->setTargetVAddr(addrs.front());
                 //For misaligns, more than 1 address is provided
                 //inst->setVAddrVector(std::move(addrs));
+            }
+            if (next_it_->isBranch())
+            {
+                inst->setTakenBranch(next_it_->isTakenBranch());
+                inst->setTargetVAddr(next_it_->branchTarget());
             }
             ++next_it_;
             return inst;

--- a/core/InstGenerator.hpp
+++ b/core/InstGenerator.hpp
@@ -40,10 +40,12 @@ namespace olympia
                                                               const std::string & filename,
                                                               const bool skip_nonuser_mode);
         virtual bool isDone() const = 0;
+        virtual void reset(const InstPtr &, const bool) = 0;
 
     protected:
         MavisType * mavis_facade_ = nullptr;
         uint64_t    unique_id_ = 0;
+        uint64_t    program_id_ = 1;
     };
 
     // Generates instructions from a JSON file
@@ -55,6 +57,9 @@ namespace olympia
         InstPtr getNextInst(const sparta::Clock * clk) override final;
 
         bool isDone() const override final;
+        void reset(const InstPtr &, const bool) override final;
+
+
     private:
         std::unique_ptr<nlohmann::json> jobj_;
         uint64_t                        curr_inst_index_ = 0;
@@ -75,6 +80,7 @@ namespace olympia
         InstPtr getNextInst(const sparta::Clock * clk) override final;
 
         bool isDone() const override final;
+        void reset(const InstPtr &, const bool) override final;
     private:
         std::unique_ptr<stf::STFInstReader> reader_;
 

--- a/core/LSU.hpp
+++ b/core/LSU.hpp
@@ -306,6 +306,9 @@ namespace olympia
         // Receive update from ROB whenever store instructions retire
         void getAckFromROB_(const InstPtr &);
 
+        // Schedule instructions for issue
+        void scheduleInst_(const InstPtr &);
+
         // Issue/Re-issue ready instructions in the issue queue
         void issueInst_();
 
@@ -356,12 +359,10 @@ namespace olympia
         void updateIssuePriorityAfterStoreInstRetire_(const InstPtr &);
 
         // Flush instruction issue queue
-        template<typename Comp>
-        void flushIssueQueue_(const Comp &);
+        void flushIssueQueue_(const FlushCriteria &);
 
         // Flush load/store pipeline
-        template<typename Comp>
-        void flushLSPipeline_(const Comp &);
+        void flushLSPipeline_(const FlushCriteria &);
 
         // Counters
         sparta::Counter lsu_insts_dispatched_{

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -171,19 +171,6 @@ namespace olympia
                     break;
                 }
 
-                // Initiate full flush on misprediction
-                if (SPARTA_EXPECT_FALSE(ex_inst.isBranchMispredict()))
-                {
-                    ILOG("Mispredicted branch " << ex_inst <<
-                        " was actually " << (ex_inst.isTakenBranch() ? "taken" : "not-taken"));
-
-                    FlushManager::FlushingCriteria criteria(FlushManager::FlushEvent::MISPREDICTION, ex_inst_ptr);
-                    out_retire_flush_.send(criteria);
-
-                    ++num_flushes_;
-                    break;
-                }
-
             }
             else {
                 break;

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -122,6 +122,14 @@ namespace olympia
 
                 ILOG("retiring " << ex_inst);
 
+                // Use the program ID to verify that the program order has been maintained.
+                sparta_assert(ex_inst.getProgramID() == expected_program_id_,
+                    "Unexpected program ID when retiring instruction"
+                    << "(suggests wrong program order)"
+                    << " expected: " << expected_program_id_
+                    << " received: " << ex_inst.getProgramID());
+                ++expected_program_id_;
+
                 if(SPARTA_EXPECT_FALSE((num_retired_ % retire_heartbeat_) == 0)) {
                     std::cout << "olympia: Retired " << num_retired_.get()
                               << " instructions in " << getClock()->currentCycle()
@@ -145,8 +153,21 @@ namespace olympia
                     out_retire_flush_.send(ex_inst.getUniqueID());
 
                     // Redirect fetch
-                    out_fetch_flush_redirect_.send(ex_inst.getTargetVAddr() + 4);
+                    out_fetch_flush_redirect_.send(ex_inst_ptr);
 
+                    ++num_flushes_;
+                    break;
+                }
+
+                // Initiate full flush on misprediction
+                if (SPARTA_EXPECT_FALSE(ex_inst.isBranchMispredict()))
+                {
+                    ILOG("Mispredicted branch " << ex_inst <<
+                        " was actually " << (ex_inst.isTakenBranch() ? "taken" : "not-taken"));
+                    out_retire_flush_.send(ex_inst.getUniqueID());
+
+                    // Redirect Fetch
+                    out_fetch_flush_redirect_.send(ex_inst_ptr);
                     ++num_flushes_;
                     break;
                 }

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -10,7 +10,6 @@
 #include "sparta/simulation/ParameterSet.hpp"
 #include "sparta/simulation/TreeNode.hpp"
 #include "sparta/log/MessageSource.hpp"
-#include "sparta/resources/Buffer.hpp"
 
 #include "sparta/statistics/Counter.hpp"
 #include "sparta/statistics/StatisticDef.hpp"
@@ -85,7 +84,7 @@ namespace olympia
         const uint32_t num_insts_to_retire_; // parameter from ilimit
         const uint64_t retire_heartbeat_;    // Retire heartbeat interval
 
-        sparta::Buffer<InstPtr> reorder_buffer_;
+        InstQueue      reorder_buffer_;
 
         // Bool that indicates if the ROB stopped simulation.  If
         // false and there are still instructions in the reorder

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -91,12 +91,16 @@ namespace olympia
         // buffer, the machine probably has a lock up
         bool rob_stopped_simulation_{false};
 
+        // Track a program ID to ensure the trace stream matches
+        // at retirement.
+        uint64_t expected_program_id_ = 1;
+
         // Ports used by the ROB
         sparta::DataInPort<InstGroupPtr> in_reorder_buffer_write_{&unit_port_set_, "in_reorder_buffer_write", 1};
         sparta::DataOutPort<uint32_t> out_reorder_buffer_credits_{&unit_port_set_, "out_reorder_buffer_credits"};
         sparta::DataInPort<bool>      in_oldest_completed_       {&unit_port_set_, "in_reorder_oldest_completed"};
         sparta::DataOutPort<FlushManager::FlushingCriteria> out_retire_flush_ {&unit_port_set_, "out_retire_flush"};
-        sparta::DataOutPort<uint64_t> out_fetch_flush_redirect_  {&unit_port_set_, "out_fetch_flush_redirect"};
+        sparta::DataOutPort<InstPtr>  out_fetch_flush_redirect_  {&unit_port_set_, "out_fetch_flush_redirect"};
 
         // UPDATE:
         sparta::DataOutPort<InstPtr> out_rob_retire_ack_ {&unit_port_set_, "out_rob_retire_ack"};

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -212,6 +212,7 @@ namespace olympia
 
         current_stall_ = NO_DECODE_INSTS;
 
+        uop_queue_regcount_data_.clear();
         out_uop_queue_credits_.send(uop_queue_.size());
         uop_queue_.clear();
     }


### PR DESCRIPTION
Attempting to add some branch prediction logic to Olympia. I started with a branch target buffer.

Plan is to add a simple predictor, and a return address stack next. As this will require some form of recovery following speculative updates. Forming a foundation for further branch prediction modelling.

Early branch misprediction recovery could be done at a later date, but will require some more complex mechanism for restoring rename map before restarting.

Few points of interest:

- Adding flushing on misprediction has pushed the runtime up considerable, dhrystone takes 250s+ to simulate compared to 12secs on master. It's only doing 10k flushes, I'm surprised that it has had such an impact.
- The BTB model is basically just a clone of SimpleCache2 but the address decoder was a protected const, and I needed to change it. Any suggestion on a better way to do this?
- I intend to send all the flushed instructions to rename serially so to free up the renaming registers. This has an added bonus as it can be used to cancel the scoreboard callbacks. Unless there's a better suggestion?
- Should I update the JSON instruction generator? Will require new taken/target fields
- I want the branch prediction stuff encapsulated a bit more, I was thinking of having a new flush field in the instruction set on prediction, that can trigger flushes within the different modules. i.e. BTB miss could set flush to DECODE_FLUSH, branch misprediction sets EXECUTE_FLUSH. Would have to consider whether the instruction that triggers the flush is included or excluded from the flush. Thoughts?
- Any ideas on what tests to add?