### PR TITLE
Add execute flushing

### DIFF
--- a/core/CPUTopology.cpp
+++ b/core/CPUTopology.cpp
@@ -259,11 +259,7 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
         },
         {
             "cpu.core*.rob.ports.out_retire_flush",
-            "cpu.core*.flushmanager.ports.in_retire_flush"
-        },
-        {
-            "cpu.core*.rob.ports.out_fetch_flush_redirect",
-            "cpu.core*.flushmanager.ports.in_fetch_flush_redirect"
+            "cpu.core*.flushmanager.ports.in_flush_request"
         },
         {
             "cpu.core*.rob.ports.out_rob_retire_ack",
@@ -274,27 +270,35 @@ olympia::CoreTopologySimple::CoreTopologySimple(){
             "cpu.core*.rename.ports.in_rename_retire_ack"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.dispatch.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.decode.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_lower",
+            "cpu.core*.decode.ports.in_reorder_flush"
+        },
+        {
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.rename.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.rob.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_retire_flush",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
             "cpu.core*.lsu.ports.in_reorder_flush"
         },
         {
-            "cpu.core*.flushmanager.ports.out_fetch_flush_redirect",
+            "cpu.core*.flushmanager.ports.out_flush_upper",
+            "cpu.core*.fetch.ports.in_fetch_flush_redirect"
+        },
+        {
+            "cpu.core*.flushmanager.ports.out_flush_lower",
             "cpu.core*.fetch.ports.in_fetch_flush_redirect"
         }
     };
@@ -344,8 +348,14 @@ void olympia::CoreTopologySimple::bindTree(sparta::RootTreeNode* root_node)
                 // Bind flushing
                 const std::string exe_flush_in =
                     core_node + ".execute." +  unit_name + ".ports.in_reorder_flush";;
-                const std::string flush_manager = flushmanager_ports + ".out_retire_flush";
+                const std::string flush_manager = flushmanager_ports + ".out_flush_upper";
                 bind_ports(exe_flush_in, flush_manager);
+
+                // Bind flush requests
+                const std::string exe_flush_out =
+                    core_node + ".execute." +  unit_name + ".ports.out_execute_flush";;
+                const std::string flush_manager_in = flushmanager_ports + ".in_flush_request";
+                bind_ports(exe_flush_out, flush_manager_in);
             }
         }
     }

--- a/core/Decode.cpp
+++ b/core/Decode.cpp
@@ -95,10 +95,10 @@ namespace olympia
             uop_queue_outp_.send(insts);
 
             // Decrement internal Uop Queue credits
-            uop_queue_credits_ -= num_decode;
+            uop_queue_credits_ -= insts->size();
 
             // Send credits back to Fetch to get more instructions
-            fetch_queue_credits_outp_.send(num_decode);
+            fetch_queue_credits_outp_.send(insts->size());
         }
 
         // If we still have credits to send instructions as well as

--- a/core/ExecutePipe.cpp
+++ b/core/ExecutePipe.cpp
@@ -234,7 +234,7 @@ namespace olympia
             auto inst_ptr = *delete_iter;
 
             // Remove flushed instruction from issue queue and clear scoreboard callbacks
-            if (criteria.flush(inst_ptr))
+            if (criteria.includedInFlush(inst_ptr))
             {
                 issue_queue_.erase(delete_iter);
 
@@ -258,7 +258,7 @@ namespace olympia
         {
             auto delete_iter = ready_queue_iter++;
             auto inst_ptr = *delete_iter;
-            if (criteria.flush(inst_ptr))
+            if (criteria.includedInFlush(inst_ptr))
             {
                 ready_queue_.erase(delete_iter);
                 ILOG("Flush Instruction ID: " << inst_ptr->getUniqueID() << " from ready queue");
@@ -268,7 +268,7 @@ namespace olympia
         // Cancel outstanding instructions awaiting completion and
         // instructions on their way to issue
         auto flush = [criteria](const InstPtr & inst) -> bool {
-            return criteria.flush(inst);
+            return criteria.includedInFlush(inst);
         };
         issue_inst_.cancel();
         complete_inst_.cancelIf(flush);

--- a/core/ExecutePipe.cpp
+++ b/core/ExecutePipe.cpp
@@ -68,6 +68,14 @@ namespace olympia
     // Callbacks
     void ExecutePipe::getInstsFromDispatch_(const InstPtr & ex_inst)
     {
+        sparta_assert(ex_inst->getStatus() == Inst::Status::DISPATCHED, "Bad instruction status: " << ex_inst);
+        appendIssueQueue_(ex_inst);
+        handleOperandIssueCheck_(ex_inst);
+    }
+
+        // Callback from Scoreboard to inform Operand Readiness
+    void ExecutePipe::handleOperandIssueCheck_(const InstPtr & ex_inst)
+    {
         // FIXME: Now every source operand should be ready
         const auto & src_bits = ex_inst->getSrcRegisterBitMask(reg_file_);
         if(scoreboard_views_[reg_file_]->isSet(src_bits))
@@ -106,7 +114,7 @@ namespace olympia
                 registerReadyCallback(src_bits, ex_inst->getUniqueID(),
                                       [this, ex_inst](const sparta::Scoreboard::RegisterBitMask&)
                                       {
-                                          this->getInstsFromDispatch_(ex_inst);
+                                          this->handleOperandIssueCheck_(ex_inst);
                                       });
             ILOG("Instruction NOT ready: " << ex_inst << " Bits needed:" << sparta::printBitSet(src_bits));
         }
@@ -133,7 +141,8 @@ namespace olympia
         complete_inst_.preparePayload(ex_inst_ptr)->schedule(exe_time);
         // Mark the alu as busy
         unit_busy_ = true;
-        // Pop the insturction from the scheduler and send a credit back to dispatch
+        // Pop the insturction from the ready queue and send a credit back to dispatch
+        popIssueQueue_(ex_inst_ptr);
         ready_queue_.pop_front();
         out_scheduler_credits_.send(1, 0);
     }
@@ -186,37 +195,84 @@ namespace olympia
     {
         ILOG("Got flush for criteria: " << criteria);
 
-        // Flush instructions in the ready queue
-        ReadyQueue::iterator it = ready_queue_.begin();
+        // Flush instructions in the issue queue
         uint32_t credits_to_send = 0;
-        while(it != ready_queue_.end()) {
-            if((*it)->getUniqueID() >= uint64_t(criteria)) {
-                ready_queue_.erase(it++);
+
+        auto iter = issue_queue_.begin();
+        while (iter != issue_queue_.end())
+        {
+            auto delete_iter = iter++;
+
+            auto inst_ptr = *delete_iter;
+
+            // Remove flushed instruction from issue queue and clear scoreboard callbacks
+            if (criteria.flush(inst_ptr))
+            {
+                issue_queue_.erase(delete_iter);
+
+                scoreboard_views_[reg_file_]->clearCallbacks(inst_ptr->getUniqueID());
+
                 ++credits_to_send;
-            }
-            else {
-                ++it;
+
+                ILOG("Flush Instruction ID: " << inst_ptr->getUniqueID());
             }
         }
+
         if(credits_to_send) {
             out_scheduler_credits_.send(credits_to_send, 0);
+
+            ILOG("Flush " << credits_to_send << " instructions in issue queue!");
         }
+
+        // Flush instructions in the ready queue
+        auto flush = [criteria](const InstPtr & inst) -> bool {
+            return criteria.flush(inst);
+        };
+        ready_queue_.erase(std::remove_if(ready_queue_.begin(),
+                                          ready_queue_.end(),
+                                          flush),
+                           ready_queue_.end());
 
         // Cancel outstanding instructions awaiting completion and
         // instructions on their way to issue
-        auto cancel_critera = [criteria](const InstPtr & inst) -> bool {
-            if(inst->getUniqueID() >= uint64_t(criteria)) {
-                return true;
-            }
-            return false;
-        };
-        complete_inst_.cancelIf(cancel_critera);
-        issue_inst_.cancel();
-
+        complete_inst_.cancelIf(flush);
         if(complete_inst_.getNumOutstandingEvents() == 0) {
             unit_busy_ = false;
             collected_inst_.closeRecord();
         }
+
+        if (ready_queue_.empty())
+        {
+            issue_inst_.cancel();
+        }
+
     }
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // Regular Function/Subroutine Call
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Append instruction into issue queue
+    void ExecutePipe::appendIssueQueue_(const InstPtr & inst_ptr)
+    {
+        sparta_assert(issue_queue_.size() < scheduler_size_,
+                        "Appending issue queue causes overflows!");
+
+        issue_queue_.emplace_back(inst_ptr);
+    }
+
+    // Pop completed instruction out of issue queue
+    void ExecutePipe::popIssueQueue_(const InstPtr & inst_ptr)
+    {
+        // Look for the instruction to be completed, and remove it from issue queue
+        for (auto iter = issue_queue_.begin(); iter != issue_queue_.end(); iter++) {
+            if (*iter == inst_ptr) {
+                issue_queue_.erase(iter);
+                return;
+            }
+        }
+        sparta_assert(false, "Attempt to complete instruction no longer exiting in issue queue!");
+    }
+
 
 }

--- a/core/ExecutePipe.hpp
+++ b/core/ExecutePipe.hpp
@@ -50,6 +50,8 @@ namespace olympia
             PARAMETER(uint32_t, execute_time, 1, "Time for execution")
             PARAMETER(uint32_t, scheduler_size, 8, "Scheduler queue size")
             PARAMETER(bool, in_order_issue, true, "Force in order issue")
+            HIDDEN_PARAMETER(bool, enable_random_misprediction, false,
+                             "test mode to inject random branch mispredictions")
         };
 
         /**
@@ -90,6 +92,7 @@ namespace olympia
         const uint32_t execute_time_;
         const uint32_t scheduler_size_;
         const bool in_order_issue_;
+        const bool enable_random_misprediction_;
         const core_types::RegFile reg_file_;
         sparta::collection::IterableCollector<std::list<InstPtr>>
         ready_queue_collector_ {getContainer(), "scheduler_queue",

--- a/core/ExecutePipe.hpp
+++ b/core/ExecutePipe.hpp
@@ -95,9 +95,12 @@ namespace olympia
         ready_queue_collector_ {getContainer(), "scheduler_queue",
                 &ready_queue_, scheduler_size_};
 
-        // Events used to issue and complete the instruction
+        // Events used to issue, execute and complete the instruction
         sparta::UniqueEvent<> issue_inst_{&unit_event_set_, getName() + "_issue_inst",
                 CREATE_SPARTA_HANDLER(ExecutePipe, issueInst_)};
+        sparta::PayloadEvent<InstPtr> execute_inst_{
+            &unit_event_set_, getName() + "_execute_inst",
+            CREATE_SPARTA_HANDLER_WITH_DATA(ExecutePipe, executeInst_, InstPtr)};
         sparta::PayloadEvent<InstPtr> complete_inst_{
             &unit_event_set_, getName() + "_complete_inst",
             CREATE_SPARTA_HANDLER_WITH_DATA(ExecutePipe, completeInst_, InstPtr)};
@@ -124,6 +127,9 @@ namespace olympia
 
         // Callback from Scoreboard to inform Operand Readiness
         void handleOperandIssueCheck_(const InstPtr &);
+
+        // Write result to registers
+        void executeInst_(const InstPtr&);
 
         // Used to complete the inst in the FPU
         void completeInst_(const InstPtr&);

--- a/core/ExecutePipe.hpp
+++ b/core/ExecutePipe.hpp
@@ -71,10 +71,13 @@ namespace olympia
         sparta::DataOutPort<uint32_t> out_scheduler_credits_{&unit_port_set_, "out_scheduler_credits"};
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_
             {&unit_port_set_, "in_reorder_flush", sparta::SchedulingPhase::Flush, 1};
+        sparta::DataOutPort<FlushManager::FlushingCriteria> out_execute_flush_
+            {&unit_port_set_, "out_execute_flush"};
 
         // Ready queue
         typedef std::list<InstPtr> ReadyQueue;
         ReadyQueue  ready_queue_;
+        ReadyQueue  issue_queue_;
 
         // Scoreboards
         using ScoreboardViews = std::array<std::unique_ptr<sparta::ScoreboardView>, core_types::N_REGFILES>;
@@ -119,11 +122,23 @@ namespace olympia
         void issueInst_();
         void getInstsFromDispatch_(const InstPtr&);
 
+        // Callback from Scoreboard to inform Operand Readiness
+        void handleOperandIssueCheck_(const InstPtr &);
+
         // Used to complete the inst in the FPU
         void completeInst_(const InstPtr&);
 
         // Used to flush the ALU
-        void flushInst_(const FlushManager::FlushingCriteria & criteria);
+        void flushInst_(const FlushManager::FlushingCriteria &);
+
+        ////////////////////////////////////////////////////////////////////////////////
+        // Regular Function/Subroutine Call
+
+        // Append new instruction into issue queue
+        void appendIssueQueue_(const InstPtr &);
+
+        // Pop completed instruction out of issue queue
+        void popIssueQueue_(const InstPtr &);
 
         // Friend class used in rename testing
         friend class ExecutePipeTester;

--- a/core/Fetch.hpp
+++ b/core/Fetch.hpp
@@ -18,6 +18,7 @@
 
 #include "CoreTypes.hpp"
 #include "InstGroup.hpp"
+#include "FlushManager.hpp"
 
 namespace olympia
 {
@@ -84,7 +85,7 @@ namespace olympia
             {&unit_port_set_, "in_fetch_queue_credits", sparta::SchedulingPhase::Tick, 0};
 
         // Incoming flush from Retire w/ redirect
-        sparta::DataInPort<uint64_t> in_fetch_flush_redirect_
+        sparta::DataInPort<FlushManager::FlushingCriteria> in_fetch_flush_redirect_
             {&unit_port_set_, "in_fetch_flush_redirect", sparta::SchedulingPhase::Flush, 1};
 
         ////////////////////////////////////////////////////////////////////////////////
@@ -121,8 +122,8 @@ namespace olympia
         // Read data from a trace
         void fetchInstruction_();
 
-        // Receive flush from retire
-        void flushFetch_(const uint64_t & new_addr);
+        // Receive flush from FlushManager
+        void flushFetch_(const FlushManager::FlushingCriteria &);
 
         // Are we fetching a speculative path?
         bool speculative_path_ = false;

--- a/core/FlushManager.hpp
+++ b/core/FlushManager.hpp
@@ -89,7 +89,7 @@ namespace olympia
                 return cause_ == FlushCause::MISFETCH;
             }
 
-            bool flush(const InstPtr& other) const
+            bool includedInFlush(const InstPtr& other) const
             {
                 return isInclusiveFlush() ?
                     inst_ptr_->getUniqueID() <= other->getUniqueID() :
@@ -174,7 +174,7 @@ namespace olympia
             if (pending_flush_.isValid())
             {
                 auto pending = pending_flush_.getValue();
-                if (pending.flush(flush_data.getInstPtr()))
+                if (pending.includedInFlush(flush_data.getInstPtr()))
                 {
                     return;
                 }

--- a/core/FlushManager.hpp
+++ b/core/FlushManager.hpp
@@ -14,6 +14,10 @@
 
 #include "sparta/simulation/Unit.hpp"
 #include "sparta/ports/DataPort.hpp"
+#include "sparta/utils/LogUtils.hpp"
+#include "sparta/utils/ValidValue.hpp"
+
+#include "Inst.hpp"
 
 namespace olympia
 {
@@ -38,7 +42,65 @@ namespace olympia
     class FlushManager : public sparta::Unit
     {
     public:
-        typedef uint64_t FlushingCriteria;
+
+        enum class FlushEvent : std::uint16_t {
+            TRAP = 0,
+            __FIRST = TRAP,
+            MISPREDICTION,
+            TARGET_MISPREDICTION,
+            MISFETCH,
+            POST_SYNC,
+            __LAST
+        };
+
+        class FlushingCriteria
+        {
+        public:
+            FlushingCriteria(FlushEvent cause, InstPtr inst_ptr) :
+                cause_(cause),
+                inst_ptr_(inst_ptr) {}
+
+            FlushingCriteria() = default;
+            FlushingCriteria(const FlushingCriteria &rhs) = default;
+            FlushingCriteria &operator=(const FlushingCriteria &rhs) = default;
+
+            FlushEvent getCause() const        { return cause_; } // TODO FlushEvent -> FlushCause
+            const InstPtr & getInstPtr() const { return inst_ptr_; }
+
+            bool isInclusiveFlush() const
+            {
+                static const std::map<FlushEvent, bool> inclusive_flush_map = {
+                    {FlushEvent::TRAP,                 true},
+                    {FlushEvent::MISFETCH,             true},
+                    {FlushEvent::MISPREDICTION,        false},
+                    {FlushEvent::TARGET_MISPREDICTION, false},
+                    {FlushEvent::POST_SYNC,            false}
+                };
+                if(auto match = inclusive_flush_map.find(cause_); match != inclusive_flush_map.end()) {
+                    return match->second;
+                }
+                sparta_assert(false, "Unknown flush cause: " << static_cast<uint16_t>(cause_));
+                return true;
+            }
+
+            bool isLowerPipeFlush() const
+            {
+                return cause_ == FlushEvent::MISFETCH;
+            }
+
+            bool flush(const InstPtr& other) const
+            {
+                return isInclusiveFlush() ?
+                    inst_ptr_->getUniqueID() <= other->getUniqueID() :
+                    inst_ptr_->getUniqueID() < other->getUniqueID();
+            }
+
+        private:
+            FlushEvent cause_;
+            InstPtr inst_ptr_;
+        };
+
+
         static constexpr char name[] = "flushmanager";
 
         class FlushManagerParameters : public sparta::ParameterSet
@@ -57,42 +119,96 @@ namespace olympia
          */
         FlushManager(sparta::TreeNode *rc, const FlushManagerParameters * params) :
             Unit(rc, name),
-            out_retire_flush_(getPortSet(), "out_retire_flush", false),
-            in_retire_flush_(getPortSet(), "in_retire_flush", 0),
-            out_fetch_flush_redirect_(getPortSet(), "out_fetch_flush_redirect", false),
-            in_fetch_flush_redirect_(getPortSet(), "in_fetch_flush_redirect", 0)
+            in_flush_request_(getPortSet(), "in_flush_request", 0),
+            out_flush_lower_(getPortSet(), "out_flush_lower", false),
+            out_flush_upper_(getPortSet(), "out_flush_upper", false)
         {
             (void)params;
-            in_retire_flush_.
+
+            in_flush_request_.
                 registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(FlushManager,
-                                                                      forwardRetireFlush_,
+                                                                      receiveFlush_,
                                                                       FlushingCriteria));
-            in_fetch_flush_redirect_.
-                registerConsumerHandler(CREATE_SPARTA_HANDLER_WITH_DATA(FlushManager,
-                                                                      forwardFetchRedirectFlush_,
-                                                                      uint64_t));
+
+            in_flush_request_.registerConsumerEvent(ev_flush_);
         }
 
     private:
 
         // Flushing criteria
-        sparta::DataOutPort<FlushingCriteria> out_retire_flush_;
-        sparta::DataInPort <FlushingCriteria> in_retire_flush_;
+        sparta::DataInPort <FlushingCriteria> in_flush_request_;
+        sparta::DataOutPort<FlushingCriteria> out_flush_lower_;
+        sparta::DataOutPort<FlushingCriteria> out_flush_upper_;
 
-        // Flush redirect for Fetch
-        sparta::DataOutPort<uint64_t> out_fetch_flush_redirect_;
-        sparta::DataInPort <uint64_t> in_fetch_flush_redirect_;
+        sparta::UniqueEvent<> ev_flush_ {&unit_event_set_,
+                                        "flush_event",
+                                         CREATE_SPARTA_HANDLER(FlushManager, forwardFlush_)};
 
-        // Internal method used to forward the flush to the attached
-        // listeners
-        void forwardRetireFlush_(const FlushingCriteria & flush_data) {
-            out_retire_flush_.send(flush_data);
+        // Hold oldest incoming flush request for forwarding
+        sparta::utils::ValidValue<FlushingCriteria> pending_flush_;
+
+        // Arbitrates and forwards the flush request from the input flush ports, to the output ports
+        void forwardFlush_()
+        {
+            sparta_assert(pending_flush_.isValid(), "no flush to forward onwards?");
+            auto flush_data = pending_flush_.getValue();
+            if (flush_data.isLowerPipeFlush())
+            {
+                ILOG("instigating lower pipeline flush for: " << flush_data);
+                out_flush_lower_.send(flush_data);
+            }
+            else
+            {
+                ILOG("instigating upper pipeline flush for: " << flush_data);
+                out_flush_upper_.send(flush_data);
+            }
+            pending_flush_.clearValid();
         }
 
-        // Internal method used to forward the fetch redirect
-        void forwardFetchRedirectFlush_(const uint64_t & flush_data) {
-            out_fetch_flush_redirect_.send(flush_data);
+        void receiveFlush_(const FlushingCriteria & flush_data)
+        {
+            ev_flush_.schedule();
+
+            // Capture the oldest flush request only
+            if (pending_flush_.isValid())
+            {
+                auto pending = pending_flush_.getValue();
+                if (pending.flush(flush_data.getInstPtr()))
+                {
+                    return;
+                }
+            }
+            pending_flush_ = flush_data;
         }
+
     };
-}
 
+
+    inline std::ostream & operator<<(std::ostream & os, const FlushManager::FlushEvent & event) {
+        switch(event) {
+            case FlushManager::FlushEvent::TRAP:
+                os << "TRAP";
+                break;
+            case FlushManager::FlushEvent::MISPREDICTION:
+                os << "MISPREDICTION";
+                break;
+            case FlushManager::FlushEvent::TARGET_MISPREDICTION:
+                os << "TARGET_MISPREDICTION";
+                break;
+            case FlushManager::FlushEvent::MISFETCH:
+                os << "MISFETCH";
+                break;
+            case FlushManager::FlushEvent::POST_SYNC:
+                os << "POST_SYNC";
+                break;
+            case FlushManager::FlushEvent::__LAST:
+                throw sparta::SpartaException("__LAST cannot be a valid enum event state.");
+        }
+        return os;
+    }
+
+    inline std::ostream & operator<<(std::ostream & os, const FlushManager::FlushingCriteria & criteria) {
+        os << criteria.getInstPtr() << " " << criteria.getCause();
+        return os;
+    }
+}

--- a/core/Inst.cpp
+++ b/core/Inst.cpp
@@ -5,6 +5,27 @@
 namespace olympia
 {
 
+    bool isCallInstruction(const mavis::OpcodeInfo::PtrType& opcode_info)
+    {
+        if (opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::JAL) ||
+            opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::JALR)) {
+            const int dest = opcode_info->getDestOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RD);
+            return miscutils::isOneOf(dest, 1, 5);
+        }
+        return false;
+    }
+
+    bool isReturnInstruction(const mavis::OpcodeInfo::PtrType& opcode_info)
+    {
+        if (opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::JALR)) {
+            const int dest = opcode_info->getDestOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RD);
+            const int src = opcode_info->getSourceOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RS1);
+            if (dest != src) {
+                return miscutils::isOneOf(src, 1, 5);
+            }
+        }
+        return false;
+    }
     /*!
      * \brief Construct an Instruction
      * \param opcode_info    Mavis Opcode information
@@ -23,7 +44,10 @@ namespace olympia
         is_transfer_(miscutils::isOneOf(inst_arch_info_->getTargetPipe(),
                                         InstArchInfo::TargetPipe::I2F,
                                         InstArchInfo::TargetPipe::F2I)),
-
+        is_branch_(opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::BRANCH)),
+        is_condbranch_(opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::CONDITIONAL)),
+        is_call_(isCallInstruction(opcode_info)),
+        is_return_(isReturnInstruction(opcode_info)),
         status_state_(Status::FETCHED)
     {
         sparta_assert(inst_arch_info_ != nullptr,

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <map>
-#include <tuple>
+#include <variant>
 
 namespace olympia
 {
@@ -166,7 +166,7 @@ namespace olympia
 
         // Rewind iterator used for going back in program simulation after flushes
         template<typename T>
-        void setRewindIterator(T iter) { std::get<T>(rewind_iter_) = iter; }
+        void setRewindIterator(T iter) { rewind_iter_ = iter; }
         template<typename T>
         T getRewindIterator() const { return std::get<T>(rewind_iter_); }
 
@@ -268,7 +268,7 @@ namespace olympia
         Status                 status_state_;
 
         using JSONIterator = uint64_t;
-        using RewindIterator = std::tuple<stf::STFInstReader::iterator, JSONIterator>;
+        using RewindIterator = std::variant<stf::STFInstReader::iterator, JSONIterator>;
         RewindIterator rewind_iter_;
 
         // Rename information

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -20,6 +20,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <map>
+#include <variant>
 
 namespace olympia
 {
@@ -163,8 +164,11 @@ namespace olympia
         bool getLast() const { return is_last_; }
 
         // Set the STF iterator to rewind trace when flushing
-        void setSTFIterator(stf::STFInstReader::iterator it) { stf_it_ = it; }
-        stf::STFInstReader::iterator getSTFIterator() const { return stf_it_; }
+        void setSTFIterator(stf::STFInstReader::iterator it) { trace_it_ = it; }
+        stf::STFInstReader::iterator getSTFIterator() const { return std::get<stf::STFInstReader::iterator>(trace_it_); }
+
+        void setJSONIterator(uint64_t it) { trace_it_ = it; }
+        uint64_t getJSONIterator() const { return std::get<uint64_t>(trace_it_); }
 
         // Set the instructions unique ID.  This ID in constantly
         // incremented and does not repeat.  The same instruction in a
@@ -283,7 +287,8 @@ namespace olympia
         sparta::Scheduleable * ev_retire_    = nullptr;
         Status                 status_state_;
 
-        stf::STFInstReader::iterator stf_it_; // Saved iterator to rewind tracefile
+        using TraceIterator = std::variant<stf::STFInstReader::iterator, uint64_t>;
+        TraceIterator trace_it_; // Saved iterator to rewind tracefile
 
         // Rename information
         using RegisterBitMaskArray = std::array<core_types::RegisterBitMask, core_types::RegFile::N_REGFILES>;

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -216,34 +216,10 @@ namespace olympia
         bool        isSpeculative() const  { return is_speculative_; }
         bool        isTransfer() const     { return is_transfer_; }
         bool        isTakenBranch() const  { return is_taken_branch_; }
-
-        bool isBranch() const {
-            return opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::BRANCH);
-        }
-        bool isCondBranch() const {
-            return opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::CONDITIONAL);
-        }
-
-        bool isCall() const {
-            if (opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::JAL) ||
-                opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::JALR)) {
-                const int dest = opcode_info_->getDestOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RD);
-                return miscutils::isOneOf(dest, 1, 5);
-            }
-            return false;
-        }
-
-        bool isReturn() const {
-            if (opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::JALR)) {
-                const int dest = opcode_info_->getDestOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RD);
-                const int src = opcode_info_->getSourceOpInfo().getFieldValue(mavis::InstMetaData::OperandFieldID::RS1);
-                if (dest != src) {
-                    return miscutils::isOneOf(src, 1, 5);
-                }
-            }
-            return false;
-        }
-
+        bool        isBranch() const       { return is_branch_; }
+        bool        isCondBranch() const   { return is_condbranch_; }
+        bool        isCall() const         { return is_call_; }
+        bool        isReturn() const       { return is_return_; }
 
         // Rename information
         core_types::RegisterBitMask & getSrcRegisterBitMask(const core_types::RegFile rf) {
@@ -283,6 +259,10 @@ namespace olympia
         bool                   is_speculative_ = false; // Is this instruction soon to be flushed?
         const bool             is_store_;
         const bool             is_transfer_;  // Is this a transfer instruction (F2I/I2F)
+        const bool             is_branch_;
+        const bool             is_condbranch_;
+        const bool             is_call_;
+        const bool             is_return_;
         bool                   is_taken_branch_ = false;
         sparta::Scheduleable * ev_retire_    = nullptr;
         Status                 status_state_;

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -20,7 +20,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <map>
-#include <variant>
+#include <tuple>
 
 namespace olympia
 {
@@ -163,12 +163,12 @@ namespace olympia
         void setLast() { is_last_ = true; }
         bool getLast() const { return is_last_; }
 
-        // Set the STF iterator to rewind trace when flushing
-        void setSTFIterator(stf::STFInstReader::iterator it) { trace_it_ = it; }
-        stf::STFInstReader::iterator getSTFIterator() const { return std::get<stf::STFInstReader::iterator>(trace_it_); }
 
-        void setJSONIterator(uint64_t it) { trace_it_ = it; }
-        uint64_t getJSONIterator() const { return std::get<uint64_t>(trace_it_); }
+        // Rewind iterator used for going back in program simulation after flushes
+        template<typename T>
+        void setRewindIterator(T iter) { std::get<T>(rewind_iter_) = iter; }
+        template<typename T>
+        T getRewindIterator() const { return std::get<T>(rewind_iter_); }
 
         // Set the instructions unique ID.  This ID in constantly
         // incremented and does not repeat.  The same instruction in a
@@ -267,8 +267,9 @@ namespace olympia
         sparta::Scheduleable * ev_retire_    = nullptr;
         Status                 status_state_;
 
-        using TraceIterator = std::variant<stf::STFInstReader::iterator, uint64_t>;
-        TraceIterator trace_it_; // Saved iterator to rewind tracefile
+        using JSONIterator = uint64_t;
+        using RewindIterator = std::tuple<stf::STFInstReader::iterator, JSONIterator>;
+        RewindIterator rewind_iter_;
 
         // Rename information
         using RegisterBitMaskArray = std::array<core_types::RegisterBitMask, core_types::RegFile::N_REGFILES>;

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -54,7 +54,7 @@ namespace olympia
 
     void JSONInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
     {
-        curr_inst_index_ = inst_ptr->getJSONIterator();
+        curr_inst_index_ = inst_ptr->getRewindIterator<uint64_t>();
         program_id_ = inst_ptr->getProgramID();
         if (skip)
         {
@@ -119,7 +119,7 @@ namespace olympia
             inst->setTakenBranch(taken);
         }
 
-        inst->setJSONIterator(curr_inst_index_);
+        inst->setRewindIterator<uint64_t>(curr_inst_index_);
         inst->setUniqueID(++unique_id_);
         inst->setProgramID(program_id_++);
         ++curr_inst_index_;
@@ -170,7 +170,7 @@ namespace olympia
 
     void TraceInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
     {
-        next_it_ = inst_ptr->getSTFIterator();
+        next_it_ = inst_ptr->getRewindIterator<stf::STFInstReader::iterator>();
         program_id_ = inst_ptr->getProgramID();
         if (skip)
         {
@@ -192,7 +192,7 @@ namespace olympia
             inst->setPC(next_it_->pc());
             inst->setUniqueID(++unique_id_);
             inst->setProgramID(program_id_++);
-            inst->setSTFIterator(next_it_);
+            inst->setRewindIterator<stf::STFInstReader::iterator>(next_it_);
             if (const auto& mem_accesses = next_it_->getMemoryAccesses(); !mem_accesses.empty())
             {
                 using VectorAddrType = std::vector<sparta::memory::addr_t>;

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -49,11 +49,18 @@ namespace olympia
     }
 
     bool JSONInstGenerator::isDone() const {
-        return (curr_inst_index_ == n_insts_);
+        return (curr_inst_index_ >= n_insts_);
     }
 
     void JSONInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
     {
+        curr_inst_index_ = inst_ptr->getJSONIterator();
+        program_id_ = inst_ptr->getProgramID();
+        if (skip)
+        {
+            ++curr_inst_index_;
+            ++program_id_;
+        }
     }
 
     InstPtr JSONInstGenerator::getNextInst(const sparta::Clock * clk)
@@ -107,9 +114,15 @@ namespace olympia
             inst->setTargetVAddr(vaddr);
         }
 
-        ++curr_inst_index_;
+        if (jinst.find("taken") != jinst.end()) {
+            const bool taken = jinst["taken"].get<bool>();
+            inst->setTakenBranch(taken);
+        }
+
+        inst->setJSONIterator(curr_inst_index_);
         inst->setUniqueID(++unique_id_);
-        inst->setProgramID(unique_id_);
+        inst->setProgramID(program_id_++);
+        ++curr_inst_index_;
         if(isDone()) {
             inst->setLast();
         }

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -52,6 +52,10 @@ namespace olympia
         return (curr_inst_index_ == n_insts_);
     }
 
+    void JSONInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
+    {
+    }
+
     InstPtr JSONInstGenerator::getNextInst(const sparta::Clock * clk)
     {
         if(SPARTA_EXPECT_FALSE(isDone())) {
@@ -150,6 +154,18 @@ namespace olympia
     bool TraceInstGenerator::isDone() const {
         return next_it_ == reader_->end();
     }
+
+    void TraceInstGenerator::reset(const InstPtr & inst_ptr, const bool skip = false)
+    {
+        next_it_ = inst_ptr->getSTFIterator();
+        program_id_ = inst_ptr->getProgramID();
+        if (skip)
+        {
+            ++next_it_;
+            ++program_id_;
+        }
+    }
+
     InstPtr TraceInstGenerator::getNextInst(const sparta::Clock * clk)
     {
         if(SPARTA_EXPECT_FALSE(isDone())) {
@@ -162,7 +178,8 @@ namespace olympia
             InstPtr inst = mavis_facade_->makeInst(opcode, clk);
             inst->setPC(next_it_->pc());
             inst->setUniqueID(++unique_id_);
-            inst->setProgramID(unique_id_);
+            inst->setProgramID(program_id_++);
+            inst->setSTFIterator(next_it_);
             if (const auto& mem_accesses = next_it_->getMemoryAccesses(); !mem_accesses.empty())
             {
                 using VectorAddrType = std::vector<sparta::memory::addr_t>;
@@ -175,6 +192,11 @@ namespace olympia
                 inst->setTargetVAddr(addrs.front());
                 //For misaligns, more than 1 address is provided
                 //inst->setVAddrVector(std::move(addrs));
+            }
+            if (next_it_->isBranch())
+            {
+                inst->setTakenBranch(next_it_->isTakenBranch());
+                inst->setTargetVAddr(next_it_->branchTarget());
             }
             ++next_it_;
             if(isDone()) {

--- a/core/InstGenerator.hpp
+++ b/core/InstGenerator.hpp
@@ -40,10 +40,12 @@ namespace olympia
                                                               const std::string & filename,
                                                               const bool skip_nonuser_mode);
         virtual bool isDone() const = 0;
+        virtual void reset(const InstPtr &, const bool) = 0;
 
     protected:
         MavisType * mavis_facade_ = nullptr;
         uint64_t    unique_id_ = 0;
+        uint64_t    program_id_ = 1;
     };
 
     // Generates instructions from a JSON file
@@ -55,6 +57,9 @@ namespace olympia
         InstPtr getNextInst(const sparta::Clock * clk) override final;
 
         bool isDone() const override final;
+        void reset(const InstPtr &, const bool) override final;
+
+
     private:
         std::unique_ptr<nlohmann::json> jobj_;
         uint64_t                        curr_inst_index_ = 0;
@@ -75,6 +80,7 @@ namespace olympia
         InstPtr getNextInst(const sparta::Clock * clk) override final;
 
         bool isDone() const override final;
+        void reset(const InstPtr &, const bool) override final;
     private:
         std::unique_ptr<stf::STFInstReader> reader_;
 

--- a/core/LSU.cpp
+++ b/core/LSU.cpp
@@ -43,10 +43,10 @@ namespace olympia
                       "Cache read stage should atleast be one cycle");
         sparta_assert(p->cache_lookup_stage_length > 0,
                       "Cache lookup stage should atleast be one cycle");
+
         // Pipeline collection config
         ldst_pipeline_.enableCollection(node);
         ldst_inst_queue_.enableCollection(node);
-
         replay_buffer_.enableCollection(node);
 
         // Startup handler for sending initial credits
@@ -94,14 +94,15 @@ namespace olympia
         ldst_pipeline_.registerHandlerAtStage(cache_lookup_stage_,
                                               CREATE_SPARTA_HANDLER(LSU, handleCacheLookupReq_));
 
-        node->getParent()->registerForNotification<bool, LSU, &LSU::onROBTerminate_>(
-            this, "rob_stopped_notif_channel", false /* ROB maybe not be constructed yet */);
-
         ldst_pipeline_.registerHandlerAtStage(cache_read_stage_,
                                               CREATE_SPARTA_HANDLER(LSU, handleCacheRead_));
 
         ldst_pipeline_.registerHandlerAtStage(complete_stage_,
                                               CREATE_SPARTA_HANDLER(LSU, completeInst_));
+
+        // Capture when the simulation is stopped prematurely by the ROB i.e. hitting retire limit
+        node->getParent()->registerForNotification<bool, LSU, &LSU::onROBTerminate_>(
+            this, "rob_stopped_notif_channel", false /* ROB maybe not be constructed yet */);
 
         uev_append_ready_ >> uev_issue_inst_;
         // NOTE:

--- a/core/LSU.cpp
+++ b/core/LSU.cpp
@@ -750,7 +750,7 @@ namespace olympia
 
         // Cancel replay events
         auto flush = [&criteria](const LoadStoreInstInfoPtr & ldst_info_ptr) -> bool {
-            return criteria.flush(ldst_info_ptr->getInstPtr());
+            return criteria.includedInFlush(ldst_info_ptr->getInstPtr());
         };
         uev_append_ready_.cancelIf(flush);
         uev_replay_ready_.cancelIf(flush);
@@ -1240,7 +1240,7 @@ namespace olympia
 
             auto delete_iter = iter++;
 
-            if (criteria.flush(inst_ptr)) {
+            if (criteria.includedInFlush(inst_ptr)) {
                 ldst_inst_queue_.erase(delete_iter);
 
                 // Clear any scoreboard callback
@@ -1278,7 +1278,7 @@ namespace olympia
             }
 
             auto inst_ptr = (*iter)->getInstPtr();
-            if (criteria.flush(inst_ptr)) {
+            if (criteria.includedInFlush(inst_ptr)) {
                 ldst_pipeline_.flushStage(iter);
 
                 ILOG("Flush Pipeline Stage[" << stage_id
@@ -1295,7 +1295,7 @@ namespace olympia
 
             auto delete_iter = iter++;
 
-            if (criteria.flush(inst_ptr)) {
+            if (criteria.includedInFlush(inst_ptr)) {
                 ready_queue_.erase(delete_iter);
                 ILOG("Flushing from ready queue - Instruction ID: " << inst_ptr->getUniqueID());
             }
@@ -1310,7 +1310,7 @@ namespace olympia
 
             auto delete_iter = iter++;
 
-            if (criteria.flush(inst_ptr)) {
+            if (criteria.includedInFlush(inst_ptr)) {
                 replay_buffer_.erase(delete_iter);
                 ILOG("Flushing from replay buffer - Instruction ID: " << inst_ptr->getUniqueID());
             }

--- a/core/LSU.hpp
+++ b/core/LSU.hpp
@@ -294,10 +294,16 @@ namespace olympia
         void updateIssuePriorityAfterStoreInstRetire_(const InstPtr &);
 
         // Flush instruction issue queue
-        template <typename Comp> void flushIssueQueue_(const Comp &);
+        void flushIssueQueue_(const FlushCriteria &);
 
         // Flush load/store pipeline
-        template <typename Comp> void flushLSPipeline_(const Comp &);
+        void flushLSPipeline_(const FlushCriteria &);
+
+        // Flush Ready Queue
+        void flushReadyQueue_(const FlushCriteria &);
+
+        // Flush Replay Buffer
+        void flushReplayBuffer_(const FlushCriteria &);
 
         // Counters
         sparta::Counter lsu_insts_dispatched_{getStatisticSet(), "lsu_insts_dispatched",

--- a/core/LSU.hpp
+++ b/core/LSU.hpp
@@ -143,11 +143,9 @@ namespace olympia
         sparta::PriorityQueue<LoadStoreInstInfoPtr> ready_queue_;
         // MMU unit
         bool mmu_busy_ = false;
-        bool mmu_pending_inst_flushed = false;
 
         // L1 Data Cache
         bool cache_busy_ = false;
-        bool cache_pending_inst_flushed_ = false;
 
         sparta::collection::Collectable<bool> cache_busy_collectable_{getContainer(), "dcache_busy",
                                                                       &cache_busy_};
@@ -285,10 +283,10 @@ namespace olympia
         void updateIssuePriorityAfterNewDispatch_(const InstPtr &);
 
         // Update issue priority after TLB reload
-        void updateIssuePriorityAfterTLBReload_(const MemoryAccessInfoPtr &, const bool = false);
+        void updateIssuePriorityAfterTLBReload_(const MemoryAccessInfoPtr &);
 
         // Update issue priority after cache reload
-        void updateIssuePriorityAfterCacheReload_(const MemoryAccessInfoPtr &, const bool = false);
+        void updateIssuePriorityAfterCacheReload_(const MemoryAccessInfoPtr &);
 
         // Update issue priority after store instruction retires
         void updateIssuePriorityAfterStoreInstRetire_(const InstPtr &);

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -173,7 +173,7 @@ namespace olympia
                 {
                     ILOG("Instigating flush... " << ex_inst);
 
-                    FlushManager::FlushingCriteria criteria(FlushManager::FlushEvent::POST_SYNC, ex_inst_ptr);
+                    FlushManager::FlushingCriteria criteria(FlushManager::FlushCause::POST_SYNC, ex_inst_ptr);
                     out_retire_flush_.send(criteria);
 
 

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -100,7 +100,7 @@ namespace olympia
         while (reorder_buffer_.size())
         {
             auto youngest_inst = reorder_buffer_.back();
-            if (criteria.flush(youngest_inst))
+            if (criteria.includedInFlush(youngest_inst))
             {
                 ILOG("flushing " << youngest_inst);
                 youngest_inst->setStatus(Inst::Status::FLUSHED);

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -91,11 +91,27 @@ namespace olympia
         ev_retire_.schedule(sparta::Clock::Cycle(0));
     }
 
-    void ROB::handleFlush_(const FlushManager::FlushingCriteria &)
+    void ROB::handleFlush_(const FlushManager::FlushingCriteria & criteria)
     {
+        uint32_t credits_to_send = 0;
+
         // Clean up internals and send new credit count
-        out_reorder_buffer_credits_.send(reorder_buffer_.size());
-        reorder_buffer_.clear();
+        while (reorder_buffer_.size())
+        {
+            auto youngest_inst = reorder_buffer_.back();
+            if (criteria.flush(youngest_inst))
+            {
+                ILOG("flushing " << youngest_inst);
+                youngest_inst->setStatus(Inst::Status::FLUSHED);
+                reorder_buffer_.pop_back();
+                ++credits_to_send;
+            }
+            else
+            {
+                break;
+            }
+        }
+        out_reorder_buffer_credits_.send(credits_to_send);
     }
 
     void ROB::retireInstructions_()
@@ -128,6 +144,14 @@ namespace olympia
 
                 ILOG("retiring " << ex_inst);
 
+                // Use the program ID to verify that the program order has been maintained.
+                sparta_assert(ex_inst.getProgramID() == expected_program_id_,
+                    "Unexpected program ID when retiring instruction"
+                    << "(suggests wrong program order)"
+                    << " expected: " << expected_program_id_
+                    << " received: " << ex_inst.getProgramID());
+                ++expected_program_id_;
+
                 if(SPARTA_EXPECT_FALSE((num_retired_ % retire_heartbeat_) == 0)) {
                     std::cout << "olympia: Retired " << num_retired_.get()
                               << " instructions in " << getClock()->currentCycle()
@@ -148,11 +172,10 @@ namespace olympia
                 if(SPARTA_EXPECT_FALSE(ex_inst.getUnit() == InstArchInfo::TargetUnit::ROB))
                 {
                     ILOG("Instigating flush... " << ex_inst);
-                    // Signal flush to the system
-                    out_retire_flush_.send(ex_inst.getUniqueID());
 
-                    // Redirect fetch
-                    out_fetch_flush_redirect_.send(ex_inst.getTargetVAddr() + 4);
+                    FlushManager::FlushingCriteria criteria(FlushManager::FlushEvent::POST_SYNC, ex_inst_ptr);
+                    out_retire_flush_.send(criteria);
+
 
                     ++num_flushes_;
                     break;

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -91,16 +91,18 @@ namespace olympia
         // buffer, the machine probably has a lock up
         bool rob_stopped_simulation_{false};
 
+        // Track a program ID to ensure the trace stream matches
+        // at retirement.
+        uint64_t expected_program_id_ = 1;
+
         // Ports used by the ROB
         sparta::DataInPort<InstGroupPtr> in_reorder_buffer_write_{&unit_port_set_, "in_reorder_buffer_write", 1};
         sparta::DataOutPort<uint32_t> out_reorder_buffer_credits_{&unit_port_set_, "out_reorder_buffer_credits"};
         sparta::DataInPort<bool>      in_oldest_completed_       {&unit_port_set_, "in_reorder_oldest_completed"};
         sparta::DataOutPort<FlushManager::FlushingCriteria> out_retire_flush_ {&unit_port_set_, "out_retire_flush"};
-        sparta::DataOutPort<uint64_t> out_fetch_flush_redirect_  {&unit_port_set_, "out_fetch_flush_redirect"};
-
         // UPDATE:
-        sparta::DataOutPort<InstPtr> out_rob_retire_ack_ {&unit_port_set_, "out_rob_retire_ack"};
-        sparta::DataOutPort<InstPtr> out_rob_retire_ack_rename_ {&unit_port_set_, "out_rob_retire_ack_rename"};
+        sparta::DataOutPort<InstPtr> out_rob_retire_ack_         {&unit_port_set_, "out_rob_retire_ack"};
+        sparta::DataOutPort<InstPtr> out_rob_retire_ack_rename_  {&unit_port_set_, "out_rob_retire_ack_rename"};
 
         // For flush
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -224,10 +224,6 @@ namespace olympia
                             freelist_[renamed_dest.rf].push(renamed_dest.val);
                         }
                     }
-                    else
-                    {
-
-                    }
                 }
 
                 const auto & srcs = inst_ptr->getRenameData().getSourceList();

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -173,6 +173,17 @@ namespace olympia
                 freelist_[src.rf].push(src.val);
             }
         }
+        // Instruction queue bookkeeping
+        if (SPARTA_EXPECT_TRUE(!inst_queue_.empty()))
+        {
+            const auto & oldest_inst = inst_queue_.front();
+            sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(), "ROB and rename inst_queue out of sync");
+            inst_queue_.pop_front();
+        }
+        else
+        {
+            sparta_assert(false, "ROB and rename inst_queue out of sync");
+        }
         if(credits_dispatch_ > 0 && (uop_queue_.size() > 0)){
             ev_schedule_rename_.schedule();
         }
@@ -184,6 +195,72 @@ namespace olympia
     void Rename::handleFlush_(const FlushManager::FlushingCriteria & criteria)
     {
         ILOG("Got a flush call for " << criteria);
+        // Restore the rename map, reference counters and freelist by walking through the inst_queue
+        while (inst_queue_.size())
+        {
+            const auto & inst_ptr = inst_queue_.back();
+            if (!criteria.flush(inst_ptr))
+            {
+                break;
+            }
+            else
+            {
+                auto const & dests = inst_ptr->getDestOpInfoList();
+                for (const auto & dest : dests)
+                {
+                    // restore rename table following a flush
+                    const auto rf  = olympia::coreutils::determineRegisterFile(dest);
+                    const auto num = dest.field_value;
+                    const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
+                    if (!is_x0)
+                    {
+                        auto const & original_dest = inst_ptr->getRenameData().getOriginalDestination();
+                        map_table_[rf][num] = original_dest.val;
+
+                        // free renamed PRF mapping when reference counter reaches zero
+                        auto const & renamed_dest = inst_ptr->getRenameData().getDestination();
+                        --reference_counter_[renamed_dest.rf][renamed_dest.val];
+                        if(reference_counter_[renamed_dest.rf][renamed_dest.val] <= 0){
+                            freelist_[renamed_dest.rf].push(renamed_dest.val);
+                        }
+                    }
+                    else
+                    {
+
+                    }
+                }
+
+                const auto & srcs = inst_ptr->getRenameData().getSourceList();
+                // decrement reference to data register
+                if(inst_ptr->isLoadStoreInst()){
+                    const auto & data_reg = inst_ptr->getRenameData().getDataReg();
+                    if(data_reg.field_id == mavis::InstMetaData::OperandFieldID::RS2 && data_reg.is_x0 != true){
+                        --reference_counter_[data_reg.rf][data_reg.val];
+                        if(reference_counter_[data_reg.rf][data_reg.val] <= 0){
+                            // freeing data register value, because it's not in the source list, so won't get caught below
+                            freelist_[data_reg.rf].push(data_reg.val);
+                        }
+                    }
+                }
+                // freeing references to PRF
+                for(const auto & src: srcs){
+                    --reference_counter_[src.rf][src.val];
+                    if(reference_counter_[src.rf][src.val] <= 0){
+                        // freeing a register in the case where it still has references and has already been retired
+                        // we wait until the last reference is retired to then free the prf
+                        // any "valid" PRF that is the true mapping of an ARF will have a reference_counter of at least 1,
+                        // and thus shouldn't be retired
+                        freelist_[src.rf].push(src.val);
+                    }
+                }
+                inst_queue_.pop_back();
+            }
+        }
+
+        current_stall_ = NO_DECODE_INSTS;
+
+        // Clean up buffers
+        uop_queue_regcount_data_.clear();
         out_uop_queue_credits_.send(uop_queue_.size());
         uop_queue_.clear();
     }
@@ -349,19 +426,20 @@ namespace olympia
                             << " for '" << rf << "' scoreboard");
                     }
                 }
-                
+
                 for(const auto & dest : dests)
                 {
                     const auto rf  = olympia::coreutils::determineRegisterFile(dest);
                     const auto num = dest.field_value;
-                    if (num == 0 && rf == core_types::RF_INTEGER) { 
-                        continue; 
+                    if (num == 0 && rf == core_types::RF_INTEGER) {
+                        continue;
                     }
                     else{
                         auto & bitmask = renaming_inst->getDestRegisterBitMask(rf);
                         const uint32_t prf = freelist_[rf].front();
                         freelist_[rf].pop();
                         renaming_inst->getRenameData().setOriginalDestination({map_table_[rf][num], rf, dest.field_id});
+                        renaming_inst->getRenameData().setDestination({prf, rf, dest.field_id});
                         map_table_[rf][num] = prf;
                         // we increase reference_counter_ for destinations to mark them as "valid",
                         // so the PRF in the reference_counter_ should have a value of 1
@@ -378,7 +456,8 @@ namespace olympia
                     }
                 }
                 // Remove it from uop queue
-                insts->emplace_back(uop_queue_.read(0));
+                insts->emplace_back(renaming_inst);
+                inst_queue_.emplace_back(renaming_inst);
                 uop_queue_.pop();
             }
 

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -199,7 +199,7 @@ namespace olympia
         while (inst_queue_.size())
         {
             const auto & inst_ptr = inst_queue_.back();
-            if (!criteria.flush(inst_ptr))
+            if (!criteria.includedInFlush(inst_ptr))
             {
                 break;
             }

--- a/core/Rename.hpp
+++ b/core/Rename.hpp
@@ -103,6 +103,10 @@ namespace olympia
         };
         std::deque<RegCountData> uop_queue_regcount_data_;
 
+        // Used to track inflight instructions for the purpose of recovering
+        // the rename data structures
+        std::deque<InstPtr> inst_queue_;
+
 
         ///////////////////////////////////////////////////////////////////////
         // Stall counters
@@ -156,7 +160,7 @@ namespace olympia
 
         // Get Retired Instructions
         void getAckFromROB_(const InstPtr &);
-        
+
         // Friend class used in rename testing
         friend class RenameTester;
 

--- a/test/sim/CMakeLists.txt
+++ b/test/sim/CMakeLists.txt
@@ -64,6 +64,15 @@ foreach(ARCH_FULL_PATH ${TEST_YAML})
     --arch ${ARCH_NAME})
 endforeach()
 
+## Test branch misprediction flushes
+foreach(ARCH_FULL_PATH ${TEST_YAML})
+  get_filename_component(ARCH_FILE_NAME ${ARCH_FULL_PATH} NAME)
+  string(REGEX REPLACE ".yaml" "" ARCH_NAME ${ARCH_FILE_NAME})
+  sparta_named_test(olympia_arch_${ARCH_NAME}_random_branch_misprediction_test olympia
+    -i500K --workload traces/dhry_riscv.zstf
+    --arch ${ARCH_NAME}
+    -p top.cpu.core0.execute.br*.params.enable_random_misprediction 1)
+endforeach()
 
 set(test_params_list)
 list(APPEND test_params_list "top.cpu.core0.lsu.params.mmu_lookup_stage_length 3")


### PR DESCRIPTION
- Fix pipeline flush mechanisms by removing inflight instructions inside functional units, recovering the rename map, and adding trace rewind functionality
- Add FlushCriteria class for requesting flushes to and from the FlushManager
- Update FlushManager to handle and arbitrate between multiple flush sources
- Add flush request port from ExecutePipe to FlushManager intended to be used for mispredicted branches
- Delay completing instructions in ExecutePipe by a cycle to fix execute flush race conditions
- Add branch identification methods for Inst
- Add test to send random flushes from the branch unit