### PR TITLE
Fix end of simulation empty buffer checks in LSU

### DIFF
--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -143,11 +143,6 @@ namespace olympia
         }
         bool isMarkedOldest() const { return is_oldest_; }
 
-        // Instruction trace/JSON generation -- mark instruction as
-        // last in trace/JSON file.
-        void setLast() { is_last_ = true; }
-        bool getLast() const { return is_last_; }
-
         // Set the instructions unique ID.  This ID in constantly
         // incremented and does not repeat.  The same instruction in a
         // trace can have different unique IDs (due to flushing)
@@ -223,7 +218,6 @@ namespace olympia
         sparta::memory::addr_t inst_pc_       = 0; // Instruction's PC
         sparta::memory::addr_t target_vaddr_  = 0; // Instruction's Target PC (for branches, loads/stores)
         bool                   is_oldest_     = false;
-        bool                   is_last_       = false;  // Is last intruction of trace
         uint64_t               unique_id_     = 0; // Supplied by Fetch
         uint64_t               program_id_    = 0; // Supplied by a trace Reader or execution backend
         bool                   is_speculative_ = false; // Is this instruction soon to be flushed?

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -106,9 +106,6 @@ namespace olympia
         ++curr_inst_index_;
         inst->setUniqueID(++unique_id_);
         inst->setProgramID(unique_id_);
-        if(isDone()) {
-            inst->setLast();
-        }
         return inst;
 
     }
@@ -177,9 +174,6 @@ namespace olympia
                 //inst->setVAddrVector(std::move(addrs));
             }
             ++next_it_;
-            if(isDone()) {
-                inst->setLast();
-            }
             return inst;
         }
         catch(std::exception & excpt) {

--- a/core/LSU.cpp
+++ b/core/LSU.cpp
@@ -94,8 +94,8 @@ namespace olympia
         ldst_pipeline_.registerHandlerAtStage(cache_lookup_stage_,
                                               CREATE_SPARTA_HANDLER(LSU, handleCacheLookupReq_));
 
-        node->getParent()->registerForNotification<bool, LSU, &LSU::onRobDrained_>(
-            this, "rob_notif_channel", false /* ROB maybe not be constructed yet */);
+        node->getParent()->registerForNotification<bool, LSU, &LSU::onROBTerminate_>(
+            this, "rob_stopped_notif_channel", false /* ROB maybe not be constructed yet */);
 
         ldst_pipeline_.registerHandlerAtStage(cache_read_stage_,
                                               CREATE_SPARTA_HANDLER(LSU, handleCacheRead_));
@@ -111,8 +111,6 @@ namespace olympia
         ILOG("LSU construct: #" << node->getGroupIdx());
     }
 
-    void LSU::onRobDrained_(const bool & val) { retire_done_ = val; }
-
     LSU::~LSU()
     {
         DLOG(getContainer()->getLocation() << ": " << load_store_info_allocator_.getNumAllocated()
@@ -121,11 +119,13 @@ namespace olympia
                                            << " MemoryAccessInfo objects allocated/created");
     }
 
+    void LSU::onROBTerminate_(const bool & val) { rob_stopped_simulation_ = val; }
+
     void LSU::onStartingTeardown_()
     {
         // If ROB has not stopped the simulation &
         // the ldst has entries to process we should fail
-        if ((false == retire_done_) && (false == ldst_inst_queue_.empty()))
+        if ((false == rob_stopped_simulation_) && (false == ldst_inst_queue_.empty()))
         {
             dumpDebugContent_(std::cerr);
             sparta_assert(false, "Issue queue has pending instructions");
@@ -992,7 +992,6 @@ namespace olympia
 
     void LSU::removeInstFromReplayQueue_(const InstPtr & inst_to_remove)
     {
-        //        return;
         ILOG("Removing Inst from replay queue " << inst_to_remove);
         for (const auto & ldst_inst : ldst_inst_queue_)
         {

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -53,12 +53,13 @@ namespace olympia
         ev_ensure_forward_progress_.setContinuing(false);
 
         // Notify other components when ROB stops the simulation
-        rob_drained_notif_source_.reset(new sparta::NotificationSource<bool>(
+        rob_stopped_notif_source_.reset(new sparta::NotificationSource<bool>(
             this->getContainer(),
-            "rob_notif_channel",
-            "Notification channel for rob",
-            "rob_notif_channel"
+            "rob_stopped_notif_channel",
+            "ROB terminated simulation channel",
+            "rob_stopped_notif_channel"
         ));
+
         // Send initial credits to anyone that cares.  Probably Dispatch.
         sparta::StartupEvent(node, CREATE_SPARTA_HANDLER(ROB, sendInitialCredits_));
     }
@@ -139,7 +140,7 @@ namespace olympia
                 // Will be true if the user provides a -i option
                 if (SPARTA_EXPECT_FALSE((num_retired_ == num_insts_to_retire_))) {
                     rob_stopped_simulation_ = true;
-                    rob_drained_notif_source_->postNotification(true);
+                    rob_stopped_notif_source_->postNotification(true);
                     getScheduler()->stopRunning();
                     break;
                 }
@@ -156,15 +157,6 @@ namespace olympia
 
                     ++num_flushes_;
                     break;
-                }
-
-                // Check to see if this is the last instruction of the
-                // trace
-                if(ex_inst.getLast()) {
-                    rob_stopped_simulation_ = true;
-                    rob_drained_notif_source_->postNotification(true);
-                    // No need to stop the scheduler -- let simulation
-                    // drain normally.  Also, don't need to check forward progress
                 }
             }
             else {

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -116,7 +116,7 @@ namespace olympia
         sparta::Event<> ev_ensure_forward_progress_{&unit_event_set_, "forward_progress_check",
                 CREATE_SPARTA_HANDLER(ROB, checkForwardProgress_)};
 
-        std::unique_ptr<sparta::NotificationSource<bool>> rob_drained_notif_source_;
+        std::unique_ptr<sparta::NotificationSource<bool>> rob_stopped_notif_source_;
 
         void sendInitialCredits_();
         void retireEvent_();


### PR DESCRIPTION
I noticed that the buffer empty termination checks weren't working as intended. 