### PR TITLE
Use MemoryAccessInfo instead of Inst for passing requests between caches and MSS

### DIFF
--- a/core/DCache.cpp
+++ b/core/DCache.cpp
@@ -15,7 +15,7 @@ namespace olympia {
             (CREATE_SPARTA_HANDLER_WITH_DATA(DCache, getAckFromL2Cache_, uint32_t));
 
         in_l2cache_resp_.registerConsumerHandler
-            (CREATE_SPARTA_HANDLER_WITH_DATA(DCache, getRespFromL2Cache_, InstPtr));
+            (CREATE_SPARTA_HANDLER_WITH_DATA(DCache, getRespFromL2Cache_, MemoryAccessInfoPtr));
 
         // DL1 cache config
         const uint32_t l1_line_size = p->l1_line_size;
@@ -84,7 +84,7 @@ namespace olympia {
             if(!busy_) {
                 busy_ = true;
                 cache_pending_inst_ = memory_access_info_ptr;
-                out_l2cache_req_.send(cache_pending_inst_->getInstPtr());
+                out_l2cache_req_.send(cache_pending_inst_);
 
                 // Set the --dcache_l2cache_credits_ here.
             }
@@ -92,19 +92,19 @@ namespace olympia {
         out_lsu_lookup_ack_.send(memory_access_info_ptr);
     }
 
-    void DCache::getRespFromL2Cache_(const InstPtr &inst_ptr) {
+    void DCache::getRespFromL2Cache_(const MemoryAccessInfoPtr &memory_access_info_ptr) {
         out_lsu_lookup_req_.send(cache_pending_inst_);
-        reloadCache_(inst_ptr->getRAdr());
+        reloadCache_(memory_access_info_ptr->getPhyAddr());
         cache_pending_inst_.reset();
         busy_ = false;
     }
 
     void DCache::getAckFromL2Cache_(const uint32_t &ack) {
         // When DCache sends the request to L2Cache for a miss,
-        // This bool will be set to false, and Dcache should wait for ack from 
+        // This bool will be set to false, and Dcache should wait for ack from
         // L2Cache notifying DCache that there is space in it's dcache request buffer
-        // 
-        // Set it to true so that the following misses from DCache can be sent out to L2Cache. 
+        //
+        // Set it to true so that the following misses from DCache can be sent out to L2Cache.
         dcache_l2cache_credits_ = ack;
     }
 

--- a/core/DCache.hpp
+++ b/core/DCache.hpp
@@ -40,7 +40,7 @@ namespace olympia
 
         void getAckFromL2Cache_(const uint32_t & ack);
 
-        void getRespFromL2Cache_(const InstPtr & inst_ptr);
+        void getRespFromL2Cache_(const MemoryAccessInfoPtr & memory_access_info_ptr);
 
         using L1Handle = CacheFuncModel::Handle;
         L1Handle l1_cache_;
@@ -61,7 +61,8 @@ namespace olympia
 
         sparta::DataInPort<uint32_t> in_l2cache_ack_{&unit_port_set_, "in_l2cache_ack", 1};
 
-        sparta::DataInPort<InstPtr> in_l2cache_resp_{&unit_port_set_, "in_l2cache_resp", 1};
+        sparta::DataInPort<MemoryAccessInfoPtr> in_l2cache_resp_{&unit_port_set_,
+                                                                 "in_l2cache_resp", 1};
 
         ////////////////////////////////////////////////////////////////////////////////
         // Output Ports
@@ -74,7 +75,8 @@ namespace olympia
         sparta::DataOutPort<MemoryAccessInfoPtr> out_lsu_lookup_req_{&unit_port_set_,
                                                                      "out_lsu_lookup_req", 1};
 
-        sparta::DataOutPort<InstPtr> out_l2cache_req_{&unit_port_set_, "out_l2cache_req", 0};
+        sparta::DataOutPort<MemoryAccessInfoPtr> out_l2cache_req_{&unit_port_set_,
+                                                                  "out_l2cache_req", 0};
 
         ////////////////////////////////////////////////////////////////////////////////
         // Events

--- a/core/MemoryAccessInfo.hpp
+++ b/core/MemoryAccessInfo.hpp
@@ -61,6 +61,8 @@ namespace olympia
 
         MemoryAccessInfo() = delete;
 
+        MemoryAccessInfo(const MemoryAccessInfo &rhs) = default;
+
         MemoryAccessInfo(const InstPtr & inst_ptr) :
             ldst_inst_ptr_(inst_ptr),
             phy_addr_ready_(false),
@@ -91,6 +93,10 @@ namespace olympia
         void setPhyAddrStatus(bool is_ready) { phy_addr_ready_ = is_ready; }
 
         bool getPhyAddrStatus() const { return phy_addr_ready_; }
+
+        uint64_t getPhyAddr() const { return ldst_inst_ptr_->getRAdr(); }
+
+        sparta::memory::addr_t getVAddr() const { return ldst_inst_ptr_->getTargetVAddr(); }
 
         void setSrcUnit(const ArchUnit & src_unit) { src_ = src_unit; }
 
@@ -157,11 +163,6 @@ namespace olympia
         // (Note : Currently used only to track request with same cacheline in L2Cache
         // Not for functional/performance purpose)
         MemoryAccessInfoPtr next_req_ = nullptr;
-
-        // Scoreboards
-        using ScoreboardViews =
-            std::array<std::unique_ptr<sparta::ScoreboardView>, core_types::N_REGFILES>;
-        ScoreboardViews scoreboard_views_;
 
         LoadStoreInstIterator issue_queue_iterator_;
         LoadStoreInstIterator replay_queue_iterator_;

--- a/mss/BIU.hpp
+++ b/mss/BIU.hpp
@@ -12,7 +12,7 @@
 #include "sparta/collection/Collectable.hpp"
 #include "sparta/events/StartupEvent.hpp"
 
-#include "Inst.hpp"
+#include "MemoryAccessInfo.hpp"
 #include "CoreTypes.hpp"
 #include "FlushManager.hpp"
 
@@ -56,7 +56,7 @@ namespace olympia_mss
         // Input Ports
         ////////////////////////////////////////////////////////////////////////////////
 
-        sparta::DataInPort<olympia::InstQueue::value_type> in_biu_req_
+        sparta::DataInPort<olympia::MemoryAccessInfoPtr> in_biu_req_
             {&unit_port_set_, "in_biu_req", 1};
 
         sparta::SyncInPort<bool> in_mss_ack_sync_
@@ -70,10 +70,10 @@ namespace olympia_mss
         sparta::DataOutPort<uint32_t> out_biu_ack_
             {&unit_port_set_, "out_biu_ack"};
 
-        sparta::DataOutPort<olympia::InstPtr> out_biu_resp_
+        sparta::DataOutPort<olympia::MemoryAccessInfoPtr> out_biu_resp_
             {&unit_port_set_, "out_biu_resp"};
 
-        sparta::SyncOutPort<olympia::InstPtr> out_mss_req_sync_
+        sparta::SyncOutPort<olympia::MemoryAccessInfoPtr> out_mss_req_sync_
             {&unit_port_set_, "out_mss_req_sync", getClock()};
 
 
@@ -81,7 +81,7 @@ namespace olympia_mss
         // Internal States
         ////////////////////////////////////////////////////////////////////////////////
 
-        using BusRequestQueue = std::list<olympia::InstPtr>;
+        using BusRequestQueue = std::list<olympia::MemoryAccessInfoPtr>;
         BusRequestQueue biu_req_queue_;
 
         const uint32_t biu_req_queue_size_;
@@ -112,7 +112,7 @@ namespace olympia_mss
         ////////////////////////////////////////////////////////////////////////////////
 
         // Receive new BIU request from L2Cache
-        void receiveReqFromL2Cache_(const olympia::InstPtr &);
+        void receiveReqFromL2Cache_(const olympia::MemoryAccessInfoPtr &);
 
         // Handle BIU request
         void handle_BIU_Req_();
@@ -135,6 +135,6 @@ namespace olympia_mss
         ////////////////////////////////////////////////////////////////////////////////
 
         // Append BIU request queue
-        void appendReqQueue_(const olympia::InstPtr &);
+        void appendReqQueue_(const olympia::MemoryAccessInfoPtr &);
     };
 }

--- a/mss/MSS.cpp
+++ b/mss/MSS.cpp
@@ -17,7 +17,7 @@ namespace olympia_mss
         mss_latency_(p->mss_latency)
     {
         in_mss_req_sync_.registerConsumerHandler
-            (CREATE_SPARTA_HANDLER_WITH_DATA(MSS, getReqFromBIU_, olympia::InstPtr));
+            (CREATE_SPARTA_HANDLER_WITH_DATA(MSS, getReqFromBIU_, olympia::MemoryAccessInfoPtr));
         in_mss_req_sync_.setPortDelay(static_cast<sparta::Clock::Cycle>(1));
 
         ILOG("MSS construct: #" << node->getGroupIdx());
@@ -29,9 +29,9 @@ namespace olympia_mss
     ////////////////////////////////////////////////////////////////////////////////
 
     // Receive new MSS request from BIU
-    void MSS::getReqFromBIU_(const olympia::InstPtr & inst_ptr)
+    void MSS::getReqFromBIU_(const olympia::MemoryAccessInfoPtr & memory_access_info_ptr)
     {
-        sparta_assert((inst_ptr != nullptr), "MSS is not handling a valid request!");
+        sparta_assert((memory_access_info_ptr != nullptr), "MSS is not handling a valid request!");
 
         // Handle MSS request event can only be scheduled when MMS is not busy
         if (!mss_busy_) {

--- a/mss/MSS.hpp
+++ b/mss/MSS.hpp
@@ -14,7 +14,7 @@
 #include "sparta/ports/SyncPort.hpp"
 #include "sparta/resources/Pipe.hpp"
 
-#include "Inst.hpp"
+#include "MemoryAccessInfo.hpp"
 #include "CoreTypes.hpp"
 #include "FlushManager.hpp"
 
@@ -53,7 +53,7 @@ namespace olympia_mss
         // Input Ports
         ////////////////////////////////////////////////////////////////////////////////
 
-        sparta::SyncInPort<olympia::InstPtr> in_mss_req_sync_
+        sparta::SyncInPort<olympia::MemoryAccessInfoPtr> in_mss_req_sync_
             {&unit_port_set_, "in_mss_req_sync", getClock()};
 
 
@@ -86,7 +86,7 @@ namespace olympia_mss
         ////////////////////////////////////////////////////////////////////////////////
 
         // Receive new MSS request from BIU
-        void getReqFromBIU_(const olympia::InstPtr &);
+        void getReqFromBIU_(const olympia::MemoryAccessInfoPtr &);
 
         // Handle MSS request
         void handle_MSS_req_();

--- a/test/core/l2cache/BIUSinkUnit.hpp
+++ b/test/core/l2cache/BIUSinkUnit.hpp
@@ -17,7 +17,7 @@ namespace l2cache_test
     {
         public:
             static constexpr char name[] = "BIUSinkUnit";
-            
+
             class BIUSinkUnitParameters : public sparta::ParameterSet
             {
             public:
@@ -29,12 +29,12 @@ namespace l2cache_test
             };
 
             BIUSinkUnit(sparta::TreeNode * n, const BIUSinkUnitParameters * params) :  sparta::Unit(n) {
-                
+
                 purpose_ = params->purpose;
                 sink_latency_ = params->sink_latency;
 
                 in_biu_req_.registerConsumerHandler
-                        (CREATE_SPARTA_HANDLER_WITH_DATA(BIUSinkUnit, sinkInst_, olympia::InstPtr));
+                        (CREATE_SPARTA_HANDLER_WITH_DATA(BIUSinkUnit, sinkInst_, olympia::MemoryAccessInfoPtr));
 
                 sparta::StartupEvent(n, CREATE_SPARTA_HANDLER(BIUSinkUnit, sendInitialCredits_));
             }
@@ -46,20 +46,20 @@ namespace l2cache_test
                 out_biu_ack_.send(biu_req_queue_size_);
                 ILOG("Sending initial credits to L2Cache : " << biu_req_queue_size_);
             }
-            
-            void sinkInst_(const olympia::InstPtr & instPtr) {
-                ILOG("Instruction: '" << instPtr << "' sinked");
+
+            void sinkInst_(const olympia::MemoryAccessInfoPtr & mem_access_info_ptr) {
+                ILOG("Instruction: '" << mem_access_info_ptr->getInstPtr() << "' sinked");
 
                 uint32_t biu_req_queue_size_ = 32;
 
                 out_biu_ack_.send(biu_req_queue_size_, sink_latency_);
-                out_biu_resp_.send(instPtr, 2*sink_latency_);
+                out_biu_resp_.send(mem_access_info_ptr, 2*sink_latency_);
             }
 
-            sparta::DataInPort<olympia::InstPtr>      in_biu_req_     {&unit_port_set_, "in_biu_req",
-                                                                                sparta::SchedulingPhase::Tick, 1};
-            sparta::DataOutPort<olympia::InstPtr>     out_biu_resp_ {&unit_port_set_, "out_biu_resp"};
-            sparta::DataOutPort<uint32_t>             out_biu_ack_ {&unit_port_set_, "out_biu_ack"};
+            sparta::DataInPort<olympia::MemoryAccessInfoPtr>  in_biu_req_     {&unit_port_set_, "in_biu_req",
+                                                                               sparta::SchedulingPhase::Tick, 1};
+            sparta::DataOutPort<olympia::MemoryAccessInfoPtr> out_biu_resp_ {&unit_port_set_, "out_biu_resp"};
+            sparta::DataOutPort<uint32_t>                     out_biu_ack_ {&unit_port_set_, "out_biu_ack"};
 
             std::string purpose_;
             sparta::Clock::Cycle sink_latency_;

--- a/test/core/l2cache/expected_output/hit_case.out.EXPECTED
+++ b/test/core/l2cache/expected_output/hit_case.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Friday Fri Nov 17 11:05:39 2023
-#Elapsed:  0.074727s
+#Start:    Saturday Sat Jan 27 08:59:40 2024
+#Elapsed:  0.004092s
 {0000000000 00000000 top.l2cache info} L2Cache: L2Cache construct: #4294967295
 {0000000000 00000000 top.l2cache info} sendInitialCredits_: Sending initial credits to ICache : 8
 {0000000000 00000000 top.l2cache info} sendInitialCredits_: Sending initial credits to DCache : 8
@@ -28,16 +28,16 @@
 {0000000003 00000003 top.dcache info} ReceiveAck_: Ack: '8' Received
 {0000000003 00000003 top.l2cache info} handle_L2Cache_DCache_Ack_: L2Cache->DCache :  Ack is sent.
 {0000000003 00000003 top.l2cache info} issue_Req_: Request is sent to Pipeline! SrcUnit : DCACHE
-{0000000011 00000011 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000011 00000011 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000011 00000011 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
-{0000000012 00000012 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000012 00000012 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000012 00000012 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
-{0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Storing the CACHE MISS in miss_pending_buffer_
 {0000000012 00000012 top.l2cache info} appendBIUReqQueue_: Append L2Cache->BIU req queue
 {0000000012 00000012 top.l2cache info} handle_L2Cache_BIU_Req_: L2Cache Request sent to BIU : Current BIU credit available = 31
 {0000000013 00000013 top.biu info} sinkInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' sinked
-{0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Storing the CACHE MISS in miss_pending_buffer_
 {0000000024 00000024 top.l2cache info} getAckFromBIU_: Ack received from BIU on the port : Current BIU credit available = 32
 {0000000034 00000034 top.l2cache info} getRespFromBIU_: Response received from BIU on the port
@@ -48,16 +48,16 @@
 {0000000035 00000035 top.l2cache info} arbitrateL2CacheAccessReqs_: Arbitration winner - BIU
 {0000000035 00000035 top.l2cache info} create_Req_: Request found in miss_pending_buffer_ with SrcUnit : DCACHE
 {0000000036 00000036 top.l2cache info} issue_Req_: Request is sent to Pipeline! SrcUnit : BIU
-{0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000044 00000044 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
 {0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Reload Complete: phyAddr=0xdeadbeef
-{0000000045 00000045 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000045 00000045 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000045 00000045 top.l2cache info} cacheLookup_: Cache HIT: phyAddr=0xdeadbeef
-{0000000045 00000045 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000045 00000045 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000045 00000045 top.l2cache info} appendICacheRespQueue_: Append L2Cache->ICache resp queue!
 {0000000045 00000045 top.l2cache info} handle_L2Cache_ICache_Resp_: L2Cache Resp is sent to ICache!
 {0000000046 00000046 top.icache info} ReceiveInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' Received
-{0000000046 00000046 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000046 00000046 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000046 00000046 top.l2cache info} appendDCacheRespQueue_: Append L2Cache->DCache resp queue!
 {0000000046 00000046 top.l2cache info} handle_L2Cache_DCache_Resp_: L2Cache Resp is sent to DCache!
 {0000000047 00000047 top.dcache info} ReceiveInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' Received
@@ -77,15 +77,15 @@
 {0000000053 00000053 top.dcache info} ReceiveAck_: Ack: '8' Received
 {0000000053 00000053 top.l2cache info} handle_L2Cache_DCache_Ack_: L2Cache->DCache :  Ack is sent.
 {0000000053 00000053 top.l2cache info} issue_Req_: Request is sent to Pipeline! SrcUnit : DCACHE
-{0000000061 00000061 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
+{0000000061 00000061 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
 {0000000061 00000061 top.l2cache info} cacheLookup_: Cache HIT: phyAddr=0xdeadbeef
-{0000000062 00000062 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
+{0000000062 00000062 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
 {0000000062 00000062 top.l2cache info} cacheLookup_: Cache HIT: phyAddr=0xdeadbeef
-{0000000062 00000062 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
+{0000000062 00000062 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
 {0000000062 00000062 top.l2cache info} appendICacheRespQueue_: Append L2Cache->ICache resp queue!
 {0000000062 00000062 top.l2cache info} handle_L2Cache_ICache_Resp_: L2Cache Resp is sent to ICache!
 {0000000063 00000063 top.icache info} ReceiveInst_: Instruction: 'uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' ' Received
-{0000000063 00000063 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
+{0000000063 00000063 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' 
 {0000000063 00000063 top.l2cache info} appendDCacheRespQueue_: Append L2Cache->DCache resp queue!
 {0000000063 00000063 top.l2cache info} handle_L2Cache_DCache_Resp_: L2Cache Resp is sent to DCache!
 {0000000064 00000064 top.dcache info} ReceiveInst_: Instruction: 'uid: 1    FETCHED 0 pid: 2 'lw	5,3,4' ' Received

--- a/test/core/l2cache/expected_output/single_access.out.EXPECTED
+++ b/test/core/l2cache/expected_output/single_access.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Friday Fri Nov 17 11:01:07 2023
-#Elapsed:  0.082742s
+#Start:    Saturday Sat Jan 27 08:59:40 2024
+#Elapsed:  0.003294s
 {0000000000 00000000 top.l2cache info} L2Cache: L2Cache construct: #4294967295
 {0000000000 00000000 top.l2cache info} sendInitialCredits_: Sending initial credits to ICache : 8
 {0000000000 00000000 top.l2cache info} sendInitialCredits_: Sending initial credits to DCache : 8
@@ -28,16 +28,16 @@
 {0000000003 00000003 top.dcache info} ReceiveAck_: Ack: '8' Received
 {0000000003 00000003 top.l2cache info} handle_L2Cache_DCache_Ack_: L2Cache->DCache :  Ack is sent.
 {0000000003 00000003 top.l2cache info} issue_Req_: Request is sent to Pipeline! SrcUnit : DCACHE
-{0000000011 00000011 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000011 00000011 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000011 00000011 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
-{0000000012 00000012 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000012 00000012 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000012 00000012 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
-{0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000012 00000012 top.l2cache info} handleCacheAccessResult_: Storing the CACHE MISS in miss_pending_buffer_
 {0000000012 00000012 top.l2cache info} appendBIUReqQueue_: Append L2Cache->BIU req queue
 {0000000012 00000012 top.l2cache info} handle_L2Cache_BIU_Req_: L2Cache Request sent to BIU : Current BIU credit available = 31
 {0000000013 00000013 top.biu info} sinkInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' sinked
-{0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000013 00000013 top.l2cache info} handleCacheAccessResult_: Storing the CACHE MISS in miss_pending_buffer_
 {0000000024 00000024 top.l2cache info} getAckFromBIU_: Ack received from BIU on the port : Current BIU credit available = 32
 {0000000034 00000034 top.l2cache info} getRespFromBIU_: Response received from BIU on the port
@@ -48,16 +48,16 @@
 {0000000035 00000035 top.l2cache info} arbitrateL2CacheAccessReqs_: Arbitration winner - BIU
 {0000000035 00000035 top.l2cache info} create_Req_: Request found in miss_pending_buffer_ with SrcUnit : DCACHE
 {0000000036 00000036 top.l2cache info} issue_Req_: Request is sent to Pipeline! SrcUnit : BIU
-{0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000044 00000044 top.l2cache info} cacheLookup_: Cache MISS: phyAddr=0xdeadbeef
 {0000000044 00000044 top.l2cache info} handleCacheAccessRequest_: Reload Complete: phyAddr=0xdeadbeef
-{0000000045 00000045 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000045 00000045 top.l2cache info} handleCacheAccessRequest_: Pipeline stage CACHE_LOOKUP : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000045 00000045 top.l2cache info} cacheLookup_: Cache HIT: phyAddr=0xdeadbeef
-{0000000045 00000045 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000045 00000045 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000045 00000045 top.l2cache info} appendICacheRespQueue_: Append L2Cache->ICache resp queue!
 {0000000045 00000045 top.l2cache info} handle_L2Cache_ICache_Resp_: L2Cache Resp is sent to ICache!
 {0000000046 00000046 top.icache info} ReceiveInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' Received
-{0000000046 00000046 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : uid: 0    FETCHED 0 pid: 1 'sw	3' 
+{0000000046 00000046 top.l2cache info} handleCacheAccessResult_: Pipeline stage HIT_MISS_HANDLING : memptr: uid: 0    FETCHED 0 pid: 1 'sw	3' 
 {0000000046 00000046 top.l2cache info} appendDCacheRespQueue_: Append L2Cache->DCache resp queue!
 {0000000046 00000046 top.l2cache info} handle_L2Cache_DCache_Resp_: L2Cache Resp is sent to DCache!
 {0000000047 00000047 top.dcache info} ReceiveInst_: Instruction: 'uid: 0    FETCHED 0 pid: 1 'sw	3' ' Received


### PR DESCRIPTION
As part of #143 use MemoryAccessInfo as the standard transaction type for making memory requests outside of the core, instead of instructions.

This paves way for adding an instruction cache, as well as prefetching and more complicated memory subsystems where requests do not always correspond to a particularly instruction.

Changes are minor, mostly just renaming.