### PR TITLE
Sparta Assert for Target Pipe without Execution Unit

### DIFF
--- a/core/Dispatch.cpp
+++ b/core/Dispatch.cpp
@@ -243,10 +243,10 @@ namespace olympia
                               "Pipe Target: "
                                   << target_pipe
                                   << " doesn't have any execution unit that can handle that target "
-                                     "pipe. Did you define it in the yaml properly?")
-                    // so we have a map here that checks for which valid dispatchers for that
-                    // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
-                    if (target_pipe != InstArchInfo::TargetPipe::LSU)
+                                     "pipe. Did you define it in the yaml properly?");
+                // so we have a map here that checks for which valid dispatchers for that
+                // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
+                if (target_pipe != InstArchInfo::TargetPipe::LSU)
                 {
                     uint32_t max_credits = 0;
                     olympia::Dispatcher* best_dispatcher = nullptr;

--- a/core/Dispatch.cpp
+++ b/core/Dispatch.cpp
@@ -239,9 +239,14 @@ namespace olympia
                                               << " not found in dispatchers, make sure pipe is "
                                                  "defined and has an assigned dispatcher");
                 auto & dispatchers = dispatchers_[static_cast<size_t>(target_pipe)];
-                // so we have a map here that checks for which valid dispatchers for that
-                // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
-                if (target_pipe != InstArchInfo::TargetPipe::LSU)
+                sparta_assert(dispatchers.size() > 0,
+                              "Pipe Target: "
+                                  << target_pipe
+                                  << " doesn't have any execution unit that can handle that target "
+                                     "pipe. Did you define it in the yaml properly?")
+                    // so we have a map here that checks for which valid dispatchers for that
+                    // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
+                    if (target_pipe != InstArchInfo::TargetPipe::LSU)
                 {
                     uint32_t max_credits = 0;
                     olympia::Dispatcher* best_dispatcher = nullptr;


### PR DESCRIPTION
Forgot to add an assert to check that there is a dispatcher (thus a subsequent issue queue/execution unit) that can handle a target pipe of an instruction. If one forgets to define one, i.e you forget to define an execution unit to handle `DIV` target pipe, the simulator will end early, but no error will be thrown.