### PR TITLE
Add SYS execute pipe

### DIFF
--- a/arches/big_core.yaml
+++ b/arches/big_core.yaml
@@ -23,7 +23,7 @@ top.cpu.core0.extension.core_extensions:
   # targets of: "int" and "div"
   pipelines:
   [
-    ["int"], # exe0
+    ["sys"], # exe0
     ["int", "div"], # exe1
     ["int", "mul"], # exe2
     ["int", "mul", "i2f", "cmov"], # exe3

--- a/arches/medium_core.yaml
+++ b/arches/medium_core.yaml
@@ -21,7 +21,7 @@ top.cpu.core0.extension.core_extensions:
   # targets of: "int" and "div"
   pipelines:
   [
-      ["int", "mul", "i2f", "cmov"], # exe0
+      ["sys", "int", "mul", "i2f", "cmov"], # exe0
       ["int", "div"], # exe1
       ["int"], # exe2
       ["float", "faddsub", "fmac"], # exe3

--- a/arches/small_core.yaml
+++ b/arches/small_core.yaml
@@ -18,7 +18,7 @@ top.cpu.core0.extension.core_extensions:
   # targets of: "int" and "div"
   pipelines:
   [
-      ["int", "mul", "i2f", "cmov", "div"], # exe0
+      ["sys", "int", "mul", "i2f", "cmov", "div"], # exe0
       ["float", "faddsub", "fmac", "f2i"], # exe1
       ["br"] # exe2
   ]

--- a/core/Dispatch.cpp
+++ b/core/Dispatch.cpp
@@ -223,14 +223,6 @@ namespace olympia
             sparta_assert(target_pipe != InstArchInfo::TargetPipe::UNKNOWN,
                           "Have an instruction that doesn't know where to go: " << ex_inst);
 
-            if (0) // SPARTA_EXPECT_FALSE(target_pipe == InstArchInfo::TargetPipe::SYS))
-            {
-                ex_inst.setStatus(Inst::Status::COMPLETED);
-                // Indicate that this instruction was dispatched
-                // -- it goes right to the ROB
-                dispatched = true;
-            }
-            else
             {
                 // Get the dispatchers used to dispatch the target.
                 // Find a ready-to-go dispatcher

--- a/core/Dispatch.cpp
+++ b/core/Dispatch.cpp
@@ -223,81 +223,79 @@ namespace olympia
             sparta_assert(target_pipe != InstArchInfo::TargetPipe::UNKNOWN,
                           "Have an instruction that doesn't know where to go: " << ex_inst);
 
+            // Get the dispatchers used to dispatch the target.
+            // Find a ready-to-go dispatcher
+            sparta_assert(static_cast<size_t>(target_pipe) < InstArchInfo::N_TARGET_PIPES,
+                          "Target pipe: " << target_pipe
+                                          << " not found in dispatchers, make sure pipe is "
+                                             "defined and has an assigned dispatcher");
+            auto & dispatchers = dispatchers_[static_cast<size_t>(target_pipe)];
+            sparta_assert(dispatchers.size() > 0,
+                          "Pipe Target: "
+                              << target_pipe
+                              << " doesn't have any execution unit that can handle that target "
+                                 "pipe. Did you define it in the yaml properly?");
+            // so we have a map here that checks for which valid dispatchers for that
+            // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
+            if (target_pipe != InstArchInfo::TargetPipe::LSU)
             {
-                // Get the dispatchers used to dispatch the target.
-                // Find a ready-to-go dispatcher
-                sparta_assert(static_cast<size_t>(target_pipe) < InstArchInfo::N_TARGET_PIPES,
-                              "Target pipe: " << target_pipe
-                                              << " not found in dispatchers, make sure pipe is "
-                                                 "defined and has an assigned dispatcher");
-                auto & dispatchers = dispatchers_[static_cast<size_t>(target_pipe)];
-                sparta_assert(dispatchers.size() > 0,
-                              "Pipe Target: "
-                                  << target_pipe
-                                  << " doesn't have any execution unit that can handle that target "
-                                     "pipe. Did you define it in the yaml properly?");
-                // so we have a map here that checks for which valid dispatchers for that
-                // instruction target pipe map needs to be: "int": [exe0, exe1, exe2]
-                if (target_pipe != InstArchInfo::TargetPipe::LSU)
+                uint32_t max_credits = 0;
+                olympia::Dispatcher* best_dispatcher = nullptr;
+                // find the dispatcher with the most amount of credits, i.e the issue queue with
+                // the least amount of entries
+                for (auto & dispatcher_iq : dispatchers)
                 {
-                    uint32_t max_credits = 0;
-                    olympia::Dispatcher* best_dispatcher = nullptr;
-                    // find the dispatcher with the most amount of credits, i.e the issue queue with
-                    // the least amount of entries
-                    for (auto & dispatcher_iq : dispatchers)
+                    if (dispatcher_iq->canAccept() && dispatcher_iq->getCredits() > max_credits)
                     {
-                        if (dispatcher_iq->canAccept() && dispatcher_iq->getCredits() > max_credits)
-                        {
-                            best_dispatcher = dispatcher_iq.get();
-                            max_credits = dispatcher_iq->getCredits();
-                        }
+                        best_dispatcher = dispatcher_iq.get();
+                        max_credits = dispatcher_iq->getCredits();
                     }
-                    if (best_dispatcher != nullptr)
+                }
+                if (best_dispatcher != nullptr)
+                {
+                    best_dispatcher->acceptInst(ex_inst_ptr);
+                    ++unit_distribution_[target_pipe];
+                    ++unit_distribution_context_.context(target_pipe);
+                    ++weighted_unit_distribution_context_.context(target_pipe);
+
+                    ex_inst_ptr->setStatus(Inst::Status::DISPATCHED);
+                    ILOG("Sending instruction: " << ex_inst_ptr << " to "
+                                                 << best_dispatcher->getName()
+                                                 << " of target type: " << target_pipe);
+                    dispatched = true;
+                }
+            }
+            else
+            {
+                for (auto & disp : dispatchers)
+                {
+                    if (disp->canAccept())
                     {
-                        best_dispatcher->acceptInst(ex_inst_ptr);
+                        disp->acceptInst(ex_inst_ptr);
                         ++unit_distribution_[target_pipe];
-                        ++unit_distribution_context_.context(target_pipe);
-                        ++weighted_unit_distribution_context_.context(target_pipe);
+                        ++(unit_distribution_context_.context(target_pipe));
+                        ++(weighted_unit_distribution_context_.context(target_pipe));
 
                         ex_inst_ptr->setStatus(Inst::Status::DISPATCHED);
                         ILOG("Sending instruction: " << ex_inst_ptr << " to "
-                                                     << best_dispatcher->getName()
-                                                     << " of target type: " << target_pipe);
+                                                     << disp->getName());
                         dispatched = true;
+
+                        break;
                     }
-                }
-                else
-                {
-                    for (auto & disp : dispatchers)
+                    else
                     {
-                        if (disp->canAccept())
-                        {
-                            disp->acceptInst(ex_inst_ptr);
-                            ++unit_distribution_[target_pipe];
-                            ++(unit_distribution_context_.context(target_pipe));
-                            ++(weighted_unit_distribution_context_.context(target_pipe));
-
-                            ex_inst_ptr->setStatus(Inst::Status::DISPATCHED);
-                            ILOG("Sending instruction: " << ex_inst_ptr << " to "
-                                                         << disp->getName());
-                            dispatched = true;
-
-                            break;
-                        }
-                        else
-                        {
-                            ILOG(disp->getName() << " cannot accept inst: " << ex_inst_ptr);
-                            blocking_dispatcher_ = target_pipe;
-                        }
+                        ILOG(disp->getName() << " cannot accept inst: " << ex_inst_ptr);
+                        blocking_dispatcher_ = target_pipe;
                     }
-                }
-                if (false == dispatched)
-                {
-                    current_stall_ = static_cast<StallReason>(target_pipe);
-                    keep_dispatching = false;
                 }
             }
-
+            if (false == dispatched)
+            {
+                current_stall_ = static_cast<StallReason>(target_pipe);
+                keep_dispatching = false;
+            }
+         
             if (dispatched)
             {
                 insts_dispatched->emplace_back(ex_inst_ptr);

--- a/core/Dispatch.cpp
+++ b/core/Dispatch.cpp
@@ -223,7 +223,7 @@ namespace olympia
             sparta_assert(target_pipe != InstArchInfo::TargetPipe::UNKNOWN,
                           "Have an instruction that doesn't know where to go: " << ex_inst);
 
-            if (SPARTA_EXPECT_FALSE(target_pipe == InstArchInfo::TargetPipe::SYS))
+            if (0) // SPARTA_EXPECT_FALSE(target_pipe == InstArchInfo::TargetPipe::SYS))
             {
                 ex_inst.setStatus(Inst::Status::COMPLETED);
                 // Indicate that this instruction was dispatched

--- a/core/Inst.cpp
+++ b/core/Inst.cpp
@@ -67,6 +67,7 @@ namespace olympia
         is_branch_(opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::BRANCH)),
         is_condbranch_(opcode_info_->isInstType(mavis::OpcodeInfo::InstructionTypes::CONDITIONAL)),
         is_call_(isCallInstruction(opcode_info)),
+        is_csr_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::CSR)),
         is_return_(isReturnInstruction(opcode_info)),
         status_state_(Status::FETCHED)
     {

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -280,6 +280,8 @@ namespace olympia
 
         bool isCall() const { return is_call_; }
 
+        bool isCSR() const { return is_csr_; }
+
         bool isReturn() const { return is_return_; }
 
         // Rename information
@@ -369,6 +371,7 @@ namespace olympia
         const bool is_branch_;
         const bool is_condbranch_;
         const bool is_call_;
+        const bool is_csr_;
         const bool is_return_;
 
         // Did this instruction mispredict?

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -256,7 +256,7 @@ namespace olympia
         // if SYS instr is not a csr instruction flush
         // if SYS instr is a csr but src1 is not x0, flush
         // otherwise it is a csr read, therefore don't flush
-        if (ex_inst->getMnemonic().substr(0,3)!="csr" || srclist.size()!=0)
+        if (ex_inst->isCSR())
         {   // this is the case if csr instr with src != x0
             DLOG("retiring SYS wr instr with src reg " << ex_inst->getMnemonic() );
 

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -73,7 +73,6 @@ namespace olympia
 
     void ROB::sendInitialCredits_()
     {
-        setupScoreboardView_() ;
         out_reorder_buffer_credits_.send(reorder_buffer_.capacity());
         ev_ensure_forward_progress_.schedule(retire_timeout_interval_);
     }
@@ -250,34 +249,7 @@ namespace olympia
         }
     }
 
-/*
-
-            using RegList = std::vector<Reg>;
-
-            void setOriginalDestination(const Reg & destination) { original_dest_ = destination; }
-
-            void setDestination(const Reg & destination) { dest_ = destination; }
-
-            void setDataReg(const Reg & data_reg) { data_reg_ = data_reg; }
-
-            void setSource(const Reg & source) { src_.emplace_back(source); }
-
-            const RegList & getSourceList() const { return src_; }
-
-            const Reg & getOriginalDestination() const { return original_dest_; }
-
-            const Reg & getDestination() const { return dest_; }
-
-            const Reg & getDataReg() const { return data_reg_; }
-
-          private:
-            Reg original_dest_;
-            Reg dest_;
-            RegList src_;
-            Reg data_reg_;
-        };
-*/
-    // sys instr doesn't have a pipe so we handle special stuff here
+    // sys gets flushed unless it is csr rd
     void ROB::retireSysInst_(InstPtr &ex_inst)
     {
         auto srclist = ex_inst->getRenameData().getSourceList();
@@ -295,31 +267,5 @@ namespace olympia
 
     }
 
-    // for SYS instr which doesn't have an exe pipe
-    void ROB::setupScoreboardView_()
-    {
-        std::string iq_name = "iq0"; // default name
-
-        if (getContainer() != nullptr)
-        {
-          const auto exe_pipe_rename =
-            olympia::coreutils::getPipeTopology(getContainer()->getParent(), "exe_pipe_rename");
-          if (exe_pipe_rename.size() > 0)
-                iq_name = exe_pipe_rename[0][1]; // just grab the first issue queue
-        }
-  
-        auto cpu_node = getContainer()->findAncestorByName("core.*");
-        if (cpu_node == nullptr)
-        {
-            cpu_node = getContainer()->getRoot();
-        }
-        const auto& rf = core_types::RF_INTEGER;
- 
-        // alu0, alu1 name is based on exe names, point to issue_queue name instead
-        DLOG("setup sb view: " << iq_name );
-        scoreboard_views_[rf].reset(
-            new sparta::ScoreboardView(iq_name, core_types::regfile_names[rf],
-                                       cpu_node)); // name needs to come from issue_queue
-    }
 }
 

--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -253,7 +253,10 @@ namespace olympia
     void ROB::retireSysInst_(InstPtr &ex_inst)
     {
         auto srclist = ex_inst->getRenameData().getSourceList();
-        if (ex_inst->getMnemonic().substr(0,3)=="csr" && srclist.size()!=0)
+        // if SYS instr is not a csr instruction flush
+        // if SYS instr is a csr but src1 is not x0, flush
+        // otherwise it is a csr read, therefore don't flush
+        if (ex_inst->getMnemonic().substr(0,3)!="csr" || srclist.size()!=0)
         {   // this is the case if csr instr with src != x0
             DLOG("retiring SYS wr instr with src reg " << ex_inst->getMnemonic() );
 

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -136,10 +136,5 @@ namespace olympia
 
         void retireSysInst_(InstPtr & );
 
-        void setupScoreboardView_() ;
-        // Scoreboards
-        using ScoreboardViews =
-            std::array<std::unique_ptr<sparta::ScoreboardView>, core_types::N_REGFILES>;
-        ScoreboardViews scoreboard_views_;
     };
 }

--- a/traces/example_json.json
+++ b/traces/example_json.json
@@ -18,6 +18,13 @@
         "rd": 5
     },
     {
+        "mnemonic": "csrrw",
+        "rs1": 1,
+        "rs2": 0,
+        "rd": 4,
+        "csr": 9
+    },
+    {
         "mnemonic": "lw",
         "rs1": 4,
         "rs2": 3,

--- a/traces/example_json.json
+++ b/traces/example_json.json
@@ -20,7 +20,6 @@
     {
         "mnemonic": "csrrw",
         "rs1": 1,
-        "rs2": 0,
         "rd": 4,
         "csr": 9
     },


### PR DESCRIPTION
This PR is a followup to https://github.com/riscv-software-src/riscv-perf-model/pull/162.

It is also discussed in: https://github.com/riscv-software-src/riscv-perf-model/issues/164
 
This PR changes the way SYS instructions are executed. Previously, SYS instructions did not go through an execution pipe but instead were dispatched to the ROB without delay, and the ROB handled the scoreboard with respect to the destination register. This PR requires the SYS instructions to pass through an execution pipe, thereby obviating any special scoreboard code in the ROB.  With the exception of CSR read instructions, the ROB will flush all SYS instructions.

This feature can be tested by running example_json.json workload, which is part of the make regress suite.  Also, the sys execute pipe was added to 3 config files big_core, medium_core and small_core.

How was this tested:
make regress passes 83/83.
 

