### PR TITLE
regress fails on unknown mnemonic csrrw

### DIFF
--- a/core/MavisUnit.cpp
+++ b/core/MavisUnit.cpp
@@ -24,6 +24,7 @@ namespace olympia
                                               isa_file_path + "/isa_rv64zba.json",
                                               isa_file_path + "/isa_rv64zbb.json",
                                               isa_file_path + "/isa_rv64zbs.json",
+                                              isa_file_path + "/isa_rv64zicsr.json",
                                               isa_file_path + "/isa_rv64c.json",
                                               isa_file_path + "/isa_rv64cf.json",
                                               isa_file_path + "/isa_rv64cd.json"};


### PR DESCRIPTION
I have regression fails, tried on riscv-perf-model and on my fork. 

Please check my work. I did not see any previous reference to this error but I could have missed it.

MavisUnit.cpp was missing this file:
isa_file_path + "/isa_rv64zicsr.json",

these tests failed for me on regress
	  1 - olympia_json_test (Subprocess aborted)
	  2 - olympia_json_test_report_text (Subprocess aborted)
	  3 - olympia_json_test_report_text_direct (Subprocess aborted)
	  4 - olympia_json_test_report_html (Subprocess aborted)

...
Exception while running
Unknown mnemonic 'csrrw' in ExtractorDirectInfo
...
terminate called after throwing an instance of 'mavis::UnknownMnemonic'
  what():  Unknown mnemonic 'csrrw' in ExtractorDirectInfo
...