### PR TITLE
Vector Uop Generator Bug

### DIFF
--- a/core/Decode.cpp
+++ b/core/Decode.cpp
@@ -271,7 +271,7 @@ namespace olympia
                     // Original instruction will act as the first UOp
                     inst->setUOpID(0); // set UOpID()
 
-                    while(vec_uop_gen_->getNumUopsRemaining() > 1)
+                    while(vec_uop_gen_->getNumUopsRemaining() >= 1)
                     {
                         const InstPtr uop = vec_uop_gen_->generateUop();
                         if (insts->size() < num_to_decode_)

--- a/core/Decode.cpp
+++ b/core/Decode.cpp
@@ -268,9 +268,6 @@ namespace olympia
                     ILOG("Vector uop gen: " << inst);
                     vec_uop_gen_->setInst(inst);
 
-                    // Original instruction will act as the first UOp
-                    inst->setUOpID(0); // set UOpID()
-
                     while(vec_uop_gen_->getNumUopsRemaining() >= 1)
                     {
                         const InstPtr uop = vec_uop_gen_->generateUop();

--- a/core/VectorUopGenerator.cpp
+++ b/core/VectorUopGenerator.cpp
@@ -25,14 +25,13 @@ namespace olympia
         // Does the instruction have tail elements?
         const uint32_t num_elems = current_VCSRs->vl / current_VCSRs->sew;
         inst->setTail(num_elems < current_VCSRs->vlmax);
-
+        // Inst counts as the first uop
+        --num_uops_to_generate_;
         if(num_uops_to_generate_ > 1)
         {
             current_inst_ = inst;
             current_inst_->setUOpCount(num_uops_to_generate_);
             ILOG("Inst: " << current_inst_ << " is being split into " << num_uops_to_generate_ << " UOPs");
-            // Inst counts as the first uop
-            --num_uops_to_generate_;
         }
         else
         {

--- a/core/VectorUopGenerator.cpp
+++ b/core/VectorUopGenerator.cpp
@@ -25,8 +25,6 @@ namespace olympia
         // Does the instruction have tail elements?
         const uint32_t num_elems = current_VCSRs->vl / current_VCSRs->sew;
         inst->setTail(num_elems < current_VCSRs->vlmax);
-        // Inst counts as the first uop
-        --num_uops_to_generate_;
         if(num_uops_to_generate_ > 1)
         {
             current_inst_ = inst;
@@ -37,6 +35,8 @@ namespace olympia
         {
             ILOG("Inst: " << inst << " does not need to generate uops");
         }
+        // Inst counts as the first uop
+        --num_uops_to_generate_;
     }
 
     const InstPtr VectorUopGenerator::generateUop()

--- a/core/VectorUopGenerator.cpp
+++ b/core/VectorUopGenerator.cpp
@@ -27,6 +27,8 @@ namespace olympia
         inst->setTail(num_elems < current_VCSRs->vlmax);
         if(num_uops_to_generate_ > 1)
         {
+            // Original instruction will act as the first UOp
+            inst->setUOpID(0); // set UOpID()
             current_inst_ = inst;
             current_inst_->setUOpCount(num_uops_to_generate_);
             ILOG("Inst: " << current_inst_ << " is being split into " << num_uops_to_generate_ << " UOPs");


### PR DESCRIPTION
The following [code](https://github.com/AaronGChan/riscv-perf-model/blob/5f86ada39301c3181e47236a3c592a5961a48e99/core/Decode.cpp#L274):
```vec_uop_gen_->getNumUopsRemaining() > 1```
doesn't perform correctly for LMUL=2, because the `num_uops_to_generate_` will be decremented to 1 on the `setInst` of `VectorUopGenerator`, so the 2nd uop is never generated.

This PR fixes logic and counting of Uops based on the parent instruction.