### PR TITLE
Added More Vector Arithmetic Instruction Support

### DIFF
--- a/arches/isa_json/gen_uarch_rv64v_json.py
+++ b/arches/isa_json/gen_uarch_rv64v_json.py
@@ -47,7 +47,31 @@ SUPPORTED_INSTS = {
     "vwsub.wx" :   {"pipe" : "vint", "uop_gen" : "ARITH_WIDE_DEST", "latency" : 1},
 
 # TODO: Vector Integer Arithmetic Instructions: Vector Integer Extension
-# TODO: Vector Integer Arithmetic Instructions: Vector Integer Add-with-Carry/Subtract-with-Borrow Instructions
+# FIXME: Requires Mavis fix to support correctly
+#    "vzext.vf2" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+#    "vsext.vf2" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+#    "vzext.vf4" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+#    "vsext.vf4" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+#    "vzext.vf8" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+#    "vsext.vf8" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
+
+# Vector Integer Arithmetic Instructions: Vector Integer Add-with-Carry/Subtract-with-Borrow Instructions
+    "vadc.vvm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vadc.vxm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vadc.vim"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vvm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vxm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vim" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vv"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vx"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmadc.vi"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsbc.vvm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsbc.vxm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmsbc.vvm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmsbc.vxm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmsbc.vv"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmsbc.vx"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+
 # Vector Integer Arithmetic Instructions: Vector Bitwise Logical Instructions
     "vand.vv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
     "vand.vx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
@@ -121,10 +145,28 @@ SUPPORTED_INSTS = {
     "vwmulsu.vv" : {"pipe" : "vmul", "uop_gen" : "ARITH_WIDE_DEST", "latency" : 3},
     "vwmulsu.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_WIDE_DEST", "latency" : 3},
 
-# TODO: Vector Integer Arithmetic Instructions: Vector Single-Width Integer Multiply-Add Instructions
-# TODO: Vector Integer Arithmetic Instructions: Vector Widening Integer Multiply-Add Instructions
+# Vector Integer Arithmetic Instructions: Vector Single-Width Integer Multiply-Add Instructions
+     "vmacc.vv"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vmacc.vx"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vnmsac.vv" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vnmsac.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vmadd.vv"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vmadd.vx"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vnmsub.vv" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+     "vnmsub.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC", "latency" : 3},
+
+# Vector Integer Arithmetic Instructions: Vector Widening Integer Multiply-Add Instructions
+     "vwmaccu.vv"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmaccu.vx"  : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmacc.vv"   : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmacc.vx"   : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmaccsu.vv" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmaccsu.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+     "vwmaccus.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
+
 # TODO: Vector Integer Arithmetic Instructions: Vector Integer Merge Instructions
 # TODO: Vector Integer Arithmetic Instructions: Vector Integer Move Instructions
+
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Saturating Add and Subtract
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Averaging Add and Subtract
 # Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Fractional Multiply with Rounding and Saturation
@@ -133,6 +175,7 @@ SUPPORTED_INSTS = {
 
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Scaling Shift Instructions
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Narrowing Fixed-Point Clip Instructions
+
 # TODO: Vector Floating-Point Instructions: Vector Floating-Point Exception Flags
 # TODO: Vector Floating-Point Instructions: Vector Single-Width Floating-Point Add/Subtract Instructions
 # TODO: Vector Floating-Point Instructions: Vector Widening Floating-Point Add/Subtract Instructions
@@ -152,10 +195,12 @@ SUPPORTED_INSTS = {
 # TODO: Vector Floating-Point Instructions: Single-Width Floating-Point/Integer Type-Convert Instructions
 # TODO: Vector Floating-Point Instructions: Widening Floating-Point/Integer Type-Convert Instructions
 # TODO: Vector Floating-Point Instructions: Narrowing Floating-Point/Integer Type-Convert Instructions
+
 # TODO: Vector Reduction Operations: Vector Single-Width Integer Reduction Instructions
 # TODO: Vector Reduction Operations: Vector Widening Integer Reduction Instructions
 # TODO: Vector Reduction Operations: Vector Single-Width Floating-Point Reduction Instructions
 # TODO: Vector Reduction Operations: Vector Widening Floating-Point Reduction Instructions
+
 # Vector Mask Instructions: Vector Mask-Register Logical Instructions
     "vmandn.mm" : {"pipe" : "vmask", "uop_gen" : "NONE", "latency" : 1},
     "vmand.mm"  : {"pipe" : "vmask", "uop_gen" : "NONE", "latency" : 1},
@@ -173,6 +218,7 @@ SUPPORTED_INSTS = {
 # TODO: Vector Mask Instructions: vmsof.m set-only-rst mask bit
 # TODO: Vector Mask Instructions: Vector Iota Instruction
 # TODO: Vector Mask Instructions: Vector Element Index Instruction
+
 # TODO: Vector Permutation Instructions: Integer Scalar Move Instructions
 # TODO: Vector Permutation Instructions: Floating-Point Scalar Move Instructions
 # TODO: Vector Permutation Instructions: Vector Slide Instructions

--- a/arches/isa_json/gen_uarch_rv64v_json.py
+++ b/arches/isa_json/gen_uarch_rv64v_json.py
@@ -56,6 +56,7 @@ SUPPORTED_INSTS = {
 #    "vsext.vf8" : {"pipe" : "vint", "uop_gen" : "ARITH_EXT", "latency" : 1},
 
 # Vector Integer Arithmetic Instructions: Vector Integer Add-with-Carry/Subtract-with-Borrow Instructions
+# FIXME: Requires Mavis fix to include vector mask
     "vadc.vvm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
     "vadc.vxm"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
     "vadc.vim"  : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
@@ -83,8 +84,25 @@ SUPPORTED_INSTS = {
     "vxor.vx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
     "vxor.vi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
 
-# TODO: Vector Integer Arithmetic Instructions: Vector Single-Width Shift Instructions
-# TODO: Vector Integer Arithmetic Instructions: Vector Narrowing Integer Right Shift Instructions
+# Vector Integer Arithmetic Instructions: Vector Single-Width Shift Instructions
+    "vsll.vv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsll.vx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsll.vi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsrl.vv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsrl.vx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsrl.vi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsra.vv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsra.vx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vsra.vi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+
+# Vector Integer Arithmetic Instructions: Vector Narrowing Integer Right Shift Instructions
+    "vnsrl.wv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vnsrl.wx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vnsrl.wi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vnsra.wv" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vnsra.wx" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vnsra.wi" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+
 # Vector Integer Arithmetic Instructions: Vector Integer Compare Instructions
     "vmseq.vv" :  {"pipe" : "vint", "uop_gen" : "ARITH_SINGLE_DEST", "latency" : 1},
     "vmseq.vx" :  {"pipe" : "vint", "uop_gen" : "ARITH_SINGLE_DEST", "latency" : 1},
@@ -164,8 +182,16 @@ SUPPORTED_INSTS = {
      "vwmaccsu.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
      "vwmaccus.vx" : {"pipe" : "vmul", "uop_gen" : "ARITH_MAC_WIDE_DEST", "latency" : 3},
 
-# TODO: Vector Integer Arithmetic Instructions: Vector Integer Merge Instructions
-# TODO: Vector Integer Arithmetic Instructions: Vector Integer Move Instructions
+# Vector Integer Arithmetic Instructions: Vector Integer Merge Instructions
+# FIXME: Requires Mavis fix to include vector mask
+    "vmerge.vvm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmerge.vxm" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmerge.vim" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+
+# Vector Integer Arithmetic Instructions: Vector Integer Move Instructions
+    "vmv.v.v" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmv.v.x" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
+    "vmv.v.i" : {"pipe" : "vint", "uop_gen" : "ARITH", "latency" : 1},
 
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Saturating Add and Subtract
 # TODO: Vector Fixed-Point Arithmetic Instructions: Vector Single-Width Averaging Add and Subtract

--- a/arches/isa_json/olympia_uarch_rv64v.json
+++ b/arches/isa_json/olympia_uarch_rv64v.json
@@ -1003,21 +1003,21 @@
     },
     {
         "mnemonic": "vmerge.vim",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmerge.vvm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmerge.vxm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmfeq.vf",
@@ -1333,21 +1333,21 @@
     },
     {
         "mnemonic": "vmv.v.i",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmv.v.v",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmv.v.x",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmv.x.s",
@@ -1453,39 +1453,39 @@
     },
     {
         "mnemonic": "vnsra.wi",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vnsra.wv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vnsra.wx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vnsrl.wi",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vnsrl.wv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vnsrl.wx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vor.vi",
@@ -1789,21 +1789,21 @@
     },
     {
         "mnemonic": "vsll.vi",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsll.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsll.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsm.v",
@@ -1849,39 +1849,39 @@
     },
     {
         "mnemonic": "vsra.vi",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsra.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsra.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsrl.vi",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsrl.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsrl.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsse16.v",

--- a/arches/isa_json/olympia_uarch_rv64v.json
+++ b/arches/isa_json/olympia_uarch_rv64v.json
@@ -25,21 +25,21 @@
     },
     {
         "mnemonic": "vadc.vim",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vadc.vvm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vadc.vxm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vadd.vi",
@@ -925,45 +925,45 @@
     },
     {
         "mnemonic": "vmacc.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vmacc.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vmadc.vim",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmadc.vvm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmadc.vxm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmadd.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vmadd.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vmand.mm",
@@ -1129,15 +1129,15 @@
     },
     {
         "mnemonic": "vmsbc.vvm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmsbc.vxm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vmsbf.m",
@@ -1429,27 +1429,27 @@
     },
     {
         "mnemonic": "vnmsac.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vnmsac.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vnmsub.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vnmsub.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC",
+        "latency": 3
     },
     {
         "mnemonic": "vnsra.wi",
@@ -1681,15 +1681,15 @@
     },
     {
         "mnemonic": "vsbc.vvm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vsbc.vxm",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vint",
+        "uop_gen": "ARITH",
+        "latency": 1
     },
     {
         "mnemonic": "vse16.v",
@@ -2053,45 +2053,45 @@
     },
     {
         "mnemonic": "vwmacc.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmacc.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmaccsu.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmaccsu.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmaccu.vv",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmaccu.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmaccus.vx",
-        "pipe": "?",
-        "uop_gen": "NONE",
-        "latency": 0
+        "pipe": "vmul",
+        "uop_gen": "ARITH_MAC_WIDE_DEST",
+        "latency": 3
     },
     {
         "mnemonic": "vwmul.vv",

--- a/core/Inst.cpp
+++ b/core/Inst.cpp
@@ -70,6 +70,7 @@ namespace olympia
         is_csr_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::CSR)),
         is_vector_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::VECTOR)),
         is_return_(isReturnInstruction(opcode_info)),
+        has_immediate_(opcode_info_->hasImmediate()),
         status_state_(Status::FETCHED)
     {
         sparta_assert(inst_arch_info_ != nullptr,

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -215,11 +215,6 @@ namespace olympia
         // UID, but different UOp IDs.
         uint64_t getUOpID() const { return uopid_.isValid() ? uopid_.getValue() : 0; }
 
-        bool hasUOps() const { return uopid_.isValid() && uopid_.getValue() == 0; }
-
-        // UOpIDs start at 1, because we use 0 as default UOpID on initialization
-        bool isUOp() const { return uopid_.isValid() && uopid_ > 0; }
-
         void setBlockingVSET(bool is_blocking_vset) { is_blocking_vset_ = is_blocking_vset; }
 
         bool isBlockingVSET() const { return is_blocking_vset_; }

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -314,8 +314,6 @@ namespace olympia
             return opcode_info_->getSourceOpInfoList();
         }
 
-        uint64_t getImmediate() const { return opcode_info_->getImmediate(); }
-
         const OpInfoList & getDestOpInfoList() const { return opcode_info_->getDestOpInfoList(); }
 
         bool hasZeroRegSource() const
@@ -334,6 +332,27 @@ namespace olympia
                 {
                     return elem.field_value == 0;
                 });
+        }
+
+        uint64_t hasImmediate() const { return opcode_info_->hasImmediate(); }
+        uint64_t getImmediate() const { return opcode_info_->getImmediate(); }
+
+        bool getVectorMaskEnabled() const
+        {
+            try
+            {
+                // If vm bit is 0, masking is enabled
+                const uint64_t vm_bit = opcode_info_->getSpecialField(mavis::OpcodeInfo::SpecialField::VM);
+                return vm_bit == 0;
+            }
+            catch (const mavis::UnsupportedExtractorSpecialFieldID & mavis_exception)
+            {
+                return false;
+            }
+            catch (const mavis::InvalidExtractorSpecialFieldID & mavis_exception)
+            {
+                return false;
+            }
         }
 
         // Static instruction information

--- a/core/Inst.hpp
+++ b/core/Inst.hpp
@@ -334,8 +334,12 @@ namespace olympia
                 });
         }
 
-        uint64_t hasImmediate() const { return opcode_info_->hasImmediate(); }
-        uint64_t getImmediate() const { return opcode_info_->getImmediate(); }
+        uint64_t getImmediate() const
+        {
+            sparta_assert(has_immediate_,
+                "Instruction does not have an immediate!");
+            return opcode_info_->getImmediate();
+        }
 
         bool getVectorMaskEnabled() const
         {
@@ -381,6 +385,8 @@ namespace olympia
         bool isCSR() const { return is_csr_; }
 
         bool isReturn() const { return is_return_; }
+
+        bool hasImmediate() const { return has_immediate_; }
 
         bool isVset() const { return inst_arch_info_->isVset(); }
 
@@ -479,6 +485,7 @@ namespace olympia
         const bool is_csr_;
         const bool is_vector_;
         const bool is_return_;
+        const bool has_immediate_;
 
         VCSRs VCSRs_;
         bool has_tail_ = false; // Does this vector uop have a tail?

--- a/core/InstArchInfo.cpp
+++ b/core/InstArchInfo.cpp
@@ -48,10 +48,12 @@ namespace olympia
     };
 
     const InstArchInfo::UopGenMap InstArchInfo::uop_gen_type_map = {
-        {"ARITH",             InstArchInfo::UopGenType::ARITH},
-        {"ARITH_SINGLE_DEST", InstArchInfo::UopGenType::ARITH_SINGLE_DEST},
-        {"ARITH_WIDE_DEST",   InstArchInfo::UopGenType::ARITH_WIDE_DEST},
-        {"NONE",              InstArchInfo::UopGenType::NONE}
+        {"ARITH",               InstArchInfo::UopGenType::ARITH},
+        {"ARITH_SINGLE_DEST",   InstArchInfo::UopGenType::ARITH_SINGLE_DEST},
+        {"ARITH_WIDE_DEST",     InstArchInfo::UopGenType::ARITH_WIDE_DEST},
+        {"ARITH_MAC",           InstArchInfo::UopGenType::ARITH_MAC},
+        {"ARITH_MAC_WIDE_DEST", InstArchInfo::UopGenType::ARITH_MAC_WIDE_DEST},
+        {"NONE",                InstArchInfo::UopGenType::NONE}
     };
 
     void InstArchInfo::update(const nlohmann::json & jobj)

--- a/core/InstArchInfo.hpp
+++ b/core/InstArchInfo.hpp
@@ -70,6 +70,8 @@ namespace olympia
             ARITH,
             ARITH_SINGLE_DEST,
             ARITH_WIDE_DEST,
+            ARITH_MAC,
+            ARITH_MAC_WIDE_DEST,
             NONE,
             UNKNOWN
         };

--- a/core/InstGenerator.cpp
+++ b/core/InstGenerator.cpp
@@ -77,90 +77,97 @@ namespace olympia
 
         // Get the JSON record at the current index
         nlohmann::json jinst = jobj_->at(curr_inst_index_);
-
-        if (jinst.find("mnemonic") == jinst.end())
-        {
-            throw sparta::SpartaException() << "Missing mnemonic at " << curr_inst_index_;
-        }
-        const std::string mnemonic = jinst["mnemonic"];
-
-        auto addElement = [&jinst](mavis::OperandInfo & operands, const std::string & key,
-                                   const mavis::InstMetaData::OperandFieldID operand_field_id,
-                                   const mavis::InstMetaData::OperandTypes operand_type)
-        {
-            if (jinst.find(key) != jinst.end())
-            {
-                operands.addElement(operand_field_id, operand_type, jinst[key].get<uint64_t>());
-            }
-        };
-
-        mavis::OperandInfo srcs;
-        addElement(srcs, "rs1", mavis::InstMetaData::OperandFieldID::RS1,
-                   mavis::InstMetaData::OperandTypes::LONG);
-        addElement(srcs, "fs1", mavis::InstMetaData::OperandFieldID::RS1,
-                   mavis::InstMetaData::OperandTypes::DOUBLE);
-        addElement(srcs, "rs2", mavis::InstMetaData::OperandFieldID::RS2,
-                   mavis::InstMetaData::OperandTypes::LONG);
-        addElement(srcs, "fs2", mavis::InstMetaData::OperandFieldID::RS2,
-                   mavis::InstMetaData::OperandTypes::DOUBLE);
-        addElement(srcs, "vs1", mavis::InstMetaData::OperandFieldID::RS1,
-                   mavis::InstMetaData::OperandTypes::VECTOR);
-        addElement(srcs, "vs2", mavis::InstMetaData::OperandFieldID::RS2,
-                   mavis::InstMetaData::OperandTypes::VECTOR);
-
-        mavis::OperandInfo dests;
-        addElement(dests, "rd", mavis::InstMetaData::OperandFieldID::RD,
-                   mavis::InstMetaData::OperandTypes::LONG);
-        addElement(dests, "fd", mavis::InstMetaData::OperandFieldID::RD,
-                   mavis::InstMetaData::OperandTypes::DOUBLE);
-        addElement(dests, "vd", mavis::InstMetaData::OperandFieldID::RD,
-                   mavis::InstMetaData::OperandTypes::VECTOR);
-
         InstPtr inst;
-        if (jinst.find("imm") != jinst.end())
+        if (jinst.find("opcode") != jinst.end())
         {
-            const uint64_t imm = jinst["imm"].get<uint64_t>();
-            mavis::ExtractorDirectOpInfoList ex_info(mnemonic, srcs, dests, imm);
-            inst = mavis_facade_->makeInstDirectly(ex_info, clk);
+            uint64_t opcode = std::strtoull(jinst["opcode"].get<std::string>().c_str(), nullptr, 0);
+            inst = mavis_facade_->makeInst(opcode, clk);
         }
         else
         {
-            mavis::ExtractorDirectOpInfoList ex_info(mnemonic, srcs, dests);
-            inst = mavis_facade_->makeInstDirectly(ex_info, clk);
-        }
+            if (jinst.find("mnemonic") == jinst.end())
+            {
+                throw sparta::SpartaException() << "Missing mnemonic at " << curr_inst_index_;
+            }
+            const std::string mnemonic = jinst["mnemonic"];
 
-        if (jinst.find("vaddr") != jinst.end())
-        {
-            uint64_t vaddr = std::strtoull(jinst["vaddr"].get<std::string>().c_str(), nullptr, 0);
-            inst->setTargetVAddr(vaddr);
-        }
-        if (jinst.find("vtype") != jinst.end())
-        {
-            // immediate, so decode from hex
-            uint64_t vtype = std::strtoull(jinst["vtype"].get<std::string>().c_str(), nullptr, 0);
-            std::string binaryString = std::bitset<32>(vtype).to_string();
-            uint32_t sew = std::pow(2, std::stoi(binaryString.substr(26, 3), nullptr, 2)) * 8;
-            uint32_t lmul = std::pow(2, std::stoi(binaryString.substr(29, 3), nullptr, 2));
-            inst->setLMUL(lmul);
-            inst->setSEW(sew);
-        }
+            auto addElement = [&jinst](mavis::OperandInfo & operands, const std::string & key,
+                                       const mavis::InstMetaData::OperandFieldID operand_field_id,
+                                       const mavis::InstMetaData::OperandTypes operand_type)
+            {
+                if (jinst.find(key) != jinst.end())
+                {
+                    operands.addElement(operand_field_id, operand_type, jinst[key].get<uint64_t>());
+                }
+            };
 
-        if (jinst.find("vta") != jinst.end())
-        {
-            const bool vta = jinst["vta"].get<uint64_t>() > 0 ? true: false;
-            inst->setVTA(vta);
-        }
+            mavis::OperandInfo srcs;
+            addElement(srcs, "rs1", mavis::InstMetaData::OperandFieldID::RS1,
+                       mavis::InstMetaData::OperandTypes::LONG);
+            addElement(srcs, "fs1", mavis::InstMetaData::OperandFieldID::RS1,
+                       mavis::InstMetaData::OperandTypes::DOUBLE);
+            addElement(srcs, "rs2", mavis::InstMetaData::OperandFieldID::RS2,
+                       mavis::InstMetaData::OperandTypes::LONG);
+            addElement(srcs, "fs2", mavis::InstMetaData::OperandFieldID::RS2,
+                       mavis::InstMetaData::OperandTypes::DOUBLE);
+            addElement(srcs, "vs1", mavis::InstMetaData::OperandFieldID::RS1,
+                       mavis::InstMetaData::OperandTypes::VECTOR);
+            addElement(srcs, "vs2", mavis::InstMetaData::OperandFieldID::RS2,
+                       mavis::InstMetaData::OperandTypes::VECTOR);
 
-        if (jinst.find("vl") != jinst.end())
-        {
-            const uint64_t vl = jinst["vl"].get<uint64_t>();
-            inst->setVL(vl);
-        }
+            mavis::OperandInfo dests;
+            addElement(dests, "rd", mavis::InstMetaData::OperandFieldID::RD,
+                       mavis::InstMetaData::OperandTypes::LONG);
+            addElement(dests, "fd", mavis::InstMetaData::OperandFieldID::RD,
+                       mavis::InstMetaData::OperandTypes::DOUBLE);
+            addElement(dests, "vd", mavis::InstMetaData::OperandFieldID::RD,
+                       mavis::InstMetaData::OperandTypes::VECTOR);
 
-        if (jinst.find("taken") != jinst.end())
-        {
-            const bool taken = jinst["taken"].get<bool>();
-            inst->setTakenBranch(taken);
+            if (jinst.find("imm") != jinst.end())
+            {
+                const uint64_t imm = jinst["imm"].get<uint64_t>();
+                mavis::ExtractorDirectOpInfoList ex_info(mnemonic, srcs, dests, imm);
+                inst = mavis_facade_->makeInstDirectly(ex_info, clk);
+            }
+            else
+            {
+                mavis::ExtractorDirectOpInfoList ex_info(mnemonic, srcs, dests);
+                inst = mavis_facade_->makeInstDirectly(ex_info, clk);
+            }
+
+            if (jinst.find("vaddr") != jinst.end())
+            {
+                uint64_t vaddr = std::strtoull(jinst["vaddr"].get<std::string>().c_str(), nullptr, 0);
+                inst->setTargetVAddr(vaddr);
+            }
+            if (jinst.find("vtype") != jinst.end())
+            {
+                // immediate, so decode from hex
+                uint64_t vtype = std::strtoull(jinst["vtype"].get<std::string>().c_str(), nullptr, 0);
+                std::string binaryString = std::bitset<32>(vtype).to_string();
+                uint32_t sew = std::pow(2, std::stoi(binaryString.substr(26, 3), nullptr, 2)) * 8;
+                uint32_t lmul = std::pow(2, std::stoi(binaryString.substr(29, 3), nullptr, 2));
+                inst->setLMUL(lmul);
+                inst->setSEW(sew);
+            }
+
+            if (jinst.find("vta") != jinst.end())
+            {
+                const bool vta = jinst["vta"].get<uint64_t>() > 0 ? true: false;
+                inst->setVTA(vta);
+            }
+
+            if (jinst.find("vl") != jinst.end())
+            {
+                const uint64_t vl = jinst["vl"].get<uint64_t>();
+                inst->setVL(vl);
+            }
+
+            if (jinst.find("taken") != jinst.end())
+            {
+                const bool taken = jinst["taken"].get<bool>();
+                inst->setTakenBranch(taken);
+            }
         }
 
         inst->setRewindIterator<uint64_t>(curr_inst_index_);

--- a/core/IssueQueue.cpp
+++ b/core/IssueQueue.cpp
@@ -117,11 +117,11 @@ namespace olympia
             {
                 // temporary fix for clearCallbacks not working
                 scoreboard_views_[reg_file]->registerReadyCallback(src_bits, ex_inst->getUniqueID(),
-                [this, ex_inst](const sparta::Scoreboard::RegisterBitMask &)
-                { this->handleOperandIssueCheck_(ex_inst); });
-                ILOG("Instruction NOT ready: " << ex_inst
-                                               << " Bits needed:" << sparta::printBitSet(src_bits)
-                                               << " rf: " << reg_file);
+                    [this, ex_inst](const sparta::Scoreboard::RegisterBitMask &)
+                    {
+                        this->handleOperandIssueCheck_(ex_inst);
+                    }
+                );
                 return false;
             }
         };
@@ -133,8 +133,11 @@ namespace olympia
 
             if (!src_ready)
             {
-                // we break to prevent multiple callbacks from being sent out
+                ILOG("Instruction NOT ready: " << ex_inst <<
+                     " Bits needed:" << sparta::printBitSet(ex_inst->getSrcRegisterBitMask(src.rf)) <<
+                     " rf: " << src.rf);
                 all_srcs_ready = false;
+                // we break to prevent multiple callbacks from being sent out
                 break;
             }
         }

--- a/core/Rename.cpp
+++ b/core/Rename.cpp
@@ -199,30 +199,13 @@ namespace olympia
         if (SPARTA_EXPECT_TRUE(!inst_queue_.empty()))
         {
             const auto & oldest_inst = inst_queue_.front();
-            if (!oldest_inst->hasUOps() && !oldest_inst->isUOp())
+            if (oldest_inst->getUOpID() == 0)
             {
-                // if instructions aren't UOp and oldest instruction doesn't have UOps
                 sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(),
                               "ROB and rename inst_queue out of sync");
             }
 
             inst_queue_.pop_front();
-
-            // pop all UOps from inst_queue_ to relaign ROB and rename inst_queue
-            if (inst_ptr->hasUOps())
-            {
-                while (inst_queue_.empty() == false)
-                {
-                    if (inst_ptr->getUOpID() == inst_queue_.front()->getUOpID())
-                    {
-                        inst_queue_.pop_front();
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
         }
         else
         {

--- a/core/VectorUopGenerator.cpp
+++ b/core/VectorUopGenerator.cpp
@@ -202,11 +202,22 @@ namespace olympia
         }
 
         // Create uop
-        mavis::ExtractorDirectOpInfoList ex_info(current_inst_->getMnemonic(),
-                                                 srcs,
-                                                 dests,
-                                                 current_inst_->getImmediate());
-        InstPtr uop = mavis_facade_->makeInstDirectly(ex_info, getClock());
+        InstPtr uop;
+        if (current_inst_->hasImmediate())
+        {
+            mavis::ExtractorDirectOpInfoList ex_info(current_inst_->getMnemonic(),
+                                                     srcs,
+                                                     dests,
+                                                     current_inst_->getImmediate());
+            uop = mavis_facade_->makeInstDirectly(ex_info, getClock());
+        }
+        else
+        {
+            mavis::ExtractorDirectOpInfoList ex_info(current_inst_->getMnemonic(),
+                                                     srcs,
+                                                     dests);
+            uop = mavis_facade_->makeInstDirectly(ex_info, getClock());
+        }
 
         return uop;
     }

--- a/core/VectorUopGenerator.cpp
+++ b/core/VectorUopGenerator.cpp
@@ -18,8 +18,9 @@ namespace olympia
         {
             constexpr bool SINGLE_DEST = false;
             constexpr bool WIDE_DEST = false;
+            constexpr bool ADD_DEST_AS_SRC = false;
             uop_gen_function_map_.emplace(InstArchInfo::UopGenType::ARITH,
-                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST>);
+                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST, ADD_DEST_AS_SRC>);
         }
 
         // Vector arithmetic single dest uop generator, only increment all src register numbers
@@ -31,8 +32,9 @@ namespace olympia
         {
             constexpr bool SINGLE_DEST = true;
             constexpr bool WIDE_DEST = false;
+            constexpr bool ADD_DEST_AS_SRC = false;
             uop_gen_function_map_.emplace(InstArchInfo::UopGenType::ARITH_SINGLE_DEST,
-                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST>);
+                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST, ADD_DEST_AS_SRC>);
         }
 
         // Vector arithmetic wide dest uop generator, only increment src register numbers for even uops
@@ -48,8 +50,41 @@ namespace olympia
         {
             constexpr bool SINGLE_DEST = false;
             constexpr bool WIDE_DEST = true;
+            constexpr bool ADD_DEST_AS_SRC = false;
             uop_gen_function_map_.emplace(InstArchInfo::UopGenType::ARITH_WIDE_DEST,
-                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST>);
+                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST, ADD_DEST_AS_SRC>);
+        }
+
+        // Vector arithmetic multiplay-add wide dest uop generator, add dest as source
+        // For a "vmacc.vv v12, v4, v8" with an LMUL of 4:
+        //      Uop 1: vwmacc.vv v12, v4, v8, v12
+        //      Uop 2: vwmacc.vv v13, v4, v8, v13
+        //      Uop 3: vwmacc.vv v14, v5, v9, v14
+        //      Uop 4: vwmacc.vv v15, v5, v9, v15
+        //      Uop 5: vwmacc.vv v16, v6, v10, v16
+        //      Uop 6: vwmacc.vv v17, v6, v10, v17
+        //      Uop 7: vwmacc.vv v18, v7, v11, v18
+        //      Uop 8: vwmacc.vv v19, v7, v11, v19
+        {
+            constexpr bool SINGLE_DEST = false;
+            constexpr bool WIDE_DEST = false;
+            constexpr bool ADD_DEST_AS_SRC = true;
+            uop_gen_function_map_.emplace(InstArchInfo::UopGenType::ARITH_MAC,
+                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST, ADD_DEST_AS_SRC>);
+        }
+
+        // Vector arithmetic multiplay-add uop generator, add dest as source
+        // For a "vmacc.vv v12, v4, v8" with an LMUL of 4:
+        //      Uop 1: vmacc.vv v12, v4, v8, v12
+        //      Uop 2: vmacc.vv v13, v5, v9, v13
+        //      Uop 3: vmacc.vv v14, v6, v10, v14
+        //      Uop 4: vmacc.vv v15, v7, v11, v15
+        {
+            constexpr bool SINGLE_DEST = false;
+            constexpr bool WIDE_DEST = true;
+            constexpr bool ADD_DEST_AS_SRC = true;
+            uop_gen_function_map_.emplace(InstArchInfo::UopGenType::ARITH_MAC_WIDE_DEST,
+                &VectorUopGenerator::generateArithUop<SINGLE_DEST, WIDE_DEST, ADD_DEST_AS_SRC>);
         }
     }
 
@@ -62,37 +97,25 @@ namespace olympia
         const auto uop_gen_type = inst->getUopGenType();
         sparta_assert(uop_gen_type != InstArchInfo::UopGenType::UNKNOWN,
             "Inst: " << current_inst_ << " uop gen type is unknown");
+        sparta_assert(uop_gen_type != InstArchInfo::UopGenType::NONE,
+            "Inst: " << current_inst_ << " uop gen type is none");
 
-        if(uop_gen_type != InstArchInfo::UopGenType::NONE)
+        // Number of vector elements processed by each uop
+        const Inst::VCSRs * current_vcsrs = inst->getVCSRs();
+        const uint64_t num_elems_per_uop = Inst::VLEN / current_vcsrs->sew;
+        // TODO: For now, generate uops for all elements even if there is a tail
+        num_uops_to_generate_ = std::ceil(current_vcsrs->vlmax / num_elems_per_uop);
+
+        if((uop_gen_type == InstArchInfo::UopGenType::ARITH_WIDE_DEST) ||
+           (uop_gen_type == InstArchInfo::UopGenType::ARITH_MAC_WIDE_DEST))
         {
-            // Number of vector elements processed by each uop
-            const Inst::VCSRs * current_vcsrs = inst->getVCSRs();
-            const uint64_t num_elems_per_uop = Inst::VLEN / current_vcsrs->sew;
-            // TODO: For now, generate uops for all elements even if there is a tail
-            num_uops_to_generate_ = std::ceil(current_vcsrs->vlmax / num_elems_per_uop);
-
-            if(uop_gen_type == InstArchInfo::UopGenType::ARITH_WIDE_DEST)
-            {
-                // TODO: Add parameter to support dual dests
-                num_uops_to_generate_ *= 2;
-            }
+            // TODO: Add parameter to support dual dests
+            num_uops_to_generate_ *= 2;
         }
 
-        if(num_uops_to_generate_ > 1)
-        {
-            // Original instruction will act as the first UOp
-            inst->setUOpID(0); // set UOpID()
-            current_inst_ = inst;
-            ILOG("Inst: " << current_inst_ << " is being split into "
-                          << num_uops_to_generate_ << " UOPs");
-        }
-        else
-        {
-            ILOG("Inst: " << inst << " does not need to generate uops");
-        }
-
-        // Inst counts as the first uop
-        --num_uops_to_generate_;
+        current_inst_ = inst;
+        ILOG("Inst: " << current_inst_ <<
+             " is being split into " << num_uops_to_generate_ << " UOPs");
     }
 
     const InstPtr VectorUopGenerator::generateUop()
@@ -104,7 +127,6 @@ namespace olympia
         // Generate uop
         auto uop_gen_func = uop_gen_function_map_.at(uop_gen_type);
         const InstPtr uop = uop_gen_func(this);
-        ++num_uops_generated_;
 
         // setting UOp instructions to have the same UID and PID as parent instruction
         uop->setUniqueID(current_inst_->getUniqueID());
@@ -119,6 +141,7 @@ namespace olympia
         uop->setUOpParent(parent_weak_ptr);
 
         // Handle last uop
+        ++num_uops_generated_;
         if(num_uops_generated_ == num_uops_to_generate_)
         {
             const uint32_t num_elems = current_vcsrs->vl / current_vcsrs->sew;
@@ -132,7 +155,7 @@ namespace olympia
         return uop;
     }
 
-    template<bool SINGLE_DEST, bool WIDE_DEST>
+    template<bool SINGLE_DEST, bool WIDE_DEST, bool ADD_DEST_AS_SRC>
     const InstPtr VectorUopGenerator::generateArithUop()
     {
         // Increment source and destination register values
@@ -163,6 +186,18 @@ namespace olympia
             for (auto & dest : dests)
             {
                 dest.field_value += num_uops_generated_;
+
+                if constexpr (ADD_DEST_AS_SRC == true)
+                {
+                    // OperandFieldID is an enum with RS1 = 0, RS2 = 1, etc. with a max RS of RS4
+                    using OperandFieldID = mavis::InstMetaData::OperandFieldID;
+                    const OperandFieldID field_id = static_cast<OperandFieldID>(srcs.size());
+                    sparta_assert(field_id <= OperandFieldID::RS_MAX,
+                        "Mavis does not support instructions with more than " << std::dec <<
+                        static_cast<std::underlying_type_t<OperandFieldID>>(OperandFieldID::RS_MAX) <<
+                        " sources");
+                    srcs.emplace_back(field_id, dest.operand_type, dest.field_value);
+                }
             }
         }
 

--- a/core/VectorUopGenerator.hpp
+++ b/core/VectorUopGenerator.hpp
@@ -48,7 +48,7 @@ namespace olympia
 
         const InstPtr generateUop();
 
-        template<bool SINGLE_DEST = false, bool WIDE_DEST = false>
+        template<bool SINGLE_DEST, bool WIDE_DEST, bool ADD_DEST_AS_SRC>
         const InstPtr generateArithUop();
 
         uint64_t getNumUopsRemaining() const { return num_uops_to_generate_; }

--- a/test/core/vector/CMakeLists.txt
+++ b/test/core/vector/CMakeLists.txt
@@ -28,4 +28,5 @@ sparta_named_test(Vector_test_multiple_vset Vector_test big_core.out -c test_cor
 sparta_named_test(Vector_test_vmulvx        Vector_test big_core.out -c test_cores/test_big_core_full.yaml --input-file vmulvx_e8m4.json)
 sparta_named_test(Vector_test_vmulvv        Vector_test big_core.out -c test_cores/test_big_core_full.yaml --input-file vwmulvv_e8m4.json)
 sparta_named_test(Vector_test_vmseqvv       Vector_test big_core.out -c test_cores/test_big_core_full.yaml --input-file vmseqvv_e8m4.json)
+sparta_named_test(Vector_test_vmaccvv       Vector_test big_core.out -c test_cores/test_big_core_full.yaml --input-file vmaccvv_e8m4.json)
 sparta_named_test(Vector_unsupported_test   Vector_test big_core.out -c test_cores/test_big_core_full_8_decode.yaml --input-file vrgather.json)

--- a/test/core/vector/Vector_test.cpp
+++ b/test/core/vector/Vector_test.cpp
@@ -255,9 +255,9 @@ void runTests(int argc, char **argv)
         decode_tester.test_vlmax(1024);
 
         // Test Retire
-        rob_tester.test_num_insts_retired(6);
-        // vset + 2 vadd.vv + vset + 4 vadd.vv uop + vset + 8 vadd.vv
-        rob_tester.test_num_uops_retired(17);
+        rob_tester.test_num_insts_retired(8);
+        // vset + 1 vadd.vv + vset + 2 vadd.vv + vset + 4 vadd.vv uop + vset + 8 vadd.vv
+        rob_tester.test_num_uops_retired(19);
     }
     else if(input_file.find("vmulvx.json") != std::string::npos)
     {

--- a/test/core/vector/multiple_vset.json
+++ b/test/core/vector/multiple_vset.json
@@ -2,10 +2,22 @@
     {
         "mnemonic": "vsetvli",
         "rs1": 0,
+        "vtype": "0x10",
+        "rd": 1,
+        "vl": 128
+    },
+    {
+        "mnemonic": "vadd.vv",
+        "vs1": 8,
+        "vs2": 9,
+        "vd": 10
+    },
+    {
+        "mnemonic": "vsetvli",
+        "rs1": 0,
         "vtype": "0x1",
         "rd": 1,
-        "vl": 512,
-        "vta": 1
+        "vl": 256
     },
     {
         "mnemonic": "vadd.vv",
@@ -18,8 +30,7 @@
         "rs1": 0,
         "vtype": "0x2",
         "rd": 1,
-        "vl": 512,
-        "vta": 1
+        "vl": 512
     },
     {
         "mnemonic": "vadd.vv",
@@ -32,8 +43,7 @@
         "rs1": 2,
         "vtype": "0x3",
         "rd": 1,
-        "vl": 1024,
-        "vta": 0
+        "vl": 1024
     },
     {
         "mnemonic": "vadd.vv",

--- a/test/core/vector/vmaccvv_e8m4.json
+++ b/test/core/vector/vmaccvv_e8m4.json
@@ -1,0 +1,22 @@
+[
+    {
+        "mnemonic": "vsetivli",
+        "rs1": 5,
+        "rd": 1,
+        "vtype": "0x2",
+        "vl": 512,
+        "vta": 0
+    },
+    {
+        "mnemonic": "vmacc.vv",
+        "vd": 0,
+        "vs1": 8,
+        "vs2": 16
+    },
+    {
+        "mnemonic": "vwmacc.vv",
+        "vd": 0,
+        "vs1": 8,
+        "vs2": 16
+    }
+]


### PR DESCRIPTION
Added support for even more vector arithmetic instructions:
- Vector Single-Width Shift Instructions
- Vector Narrowing Integer Right Shift Instructions
- Vector Single-Width Integer Multiply-Add Instructions
- Vector Widening Integer Multiply-Add Instructions
- Vector Integer Merge Instructions
- Vector Integer Move Instructions

Also redesigned how the vector uop generator handles vector instructions when only 1 uop is needed (e.g, LMUL = 1, certain vector instructions are not sequenced). The vector uop generator will always generate at least one uop which will be used in place of the "parent" instruction. This is necessary because some vector instructions require the source and/or dest registers be added. For example, the multiply-add vector instructions need to have their destination added as one of their sources.

There are two categories of vector arithmetic instructions that cannot be supported correctly because of issues with Mavis:
- Vector Integer Extension
- Vector Integer Add-with-Carry/Subtract-with-Borrow Instructions

Once these Mavis issues are resolved, all vector arithmetic instructions will be supported by Olympia.