### PR TITLE
Rename revamp

### DIFF
--- a/core/Inst.cpp
+++ b/core/Inst.cpp
@@ -1,24 +1,33 @@
 // <Inst.cpp> -*- C++ -*-
 
 #include "Inst.hpp"
+#include "RenameData.hpp"
+#include "CoreUtils.hpp"
 #include <unordered_map>
 
 namespace olympia
 {
-    const std::unordered_map<Inst::Status,std::string> Inst::status2String = {
-        { Inst::Status::BEFORE_FETCH,"BEFORE_FETCH" },
-        { Inst::Status::FETCHED,     "FETCHED"      },
-        { Inst::Status::DECODED,     "DECODED"      },
-        { Inst::Status::RENAMED,     "RENAMED"      },
-        { Inst::Status::DISPATCHED,  "DISPATCHED"   },
-        { Inst::Status::SCHEDULED,   "SCHEDULED"    },
-        { Inst::Status::COMPLETED,   "COMPLETED"    },
-        { Inst::Status::RETIRED,     "RETIRED"      },
-        { Inst::Status::FLUSHED,     "FLUSHED"      },
-        { Inst::Status::UNMOD,       "UNMOD"        },
-        { Inst::Status::FUSED,       "FUSED"        },
-        { Inst::Status::FUSION_GHOST,"FUSION_GHOST" }
-    };
+    const std::unordered_map<Inst::Status, std::string> Inst::status2String = {
+        {Inst::Status::BEFORE_FETCH, "BEFORE_FETCH"},
+        {Inst::Status::FETCHED, "FETCHED"},
+        {Inst::Status::DECODED, "DECODED"},
+        {Inst::Status::RENAMED, "RENAMED"},
+        {Inst::Status::DISPATCHED, "DISPATCHED"},
+        {Inst::Status::SCHEDULED, "SCHEDULED"},
+        {Inst::Status::COMPLETED, "COMPLETED"},
+        {Inst::Status::RETIRED, "RETIRED"},
+        {Inst::Status::FLUSHED, "FLUSHED"},
+        {Inst::Status::UNMOD, "UNMOD"},
+        {Inst::Status::FUSED, "FUSED"},
+        {Inst::Status::FUSION_GHOST, "FUSION_GHOST"}};
+
+    RenameData::OpInfoWithRegfile::OpInfoWithRegfile(const OpInfoList::value_type & op_info) :
+        field_value(op_info.field_value),
+        field_id(op_info.field_id),
+        reg_file(coreutils::determineRegisterFile(op_info)),
+        is_x0(field_value == 0 && reg_file == core_types::RF_INTEGER)
+    { }
+
 
     bool isCallInstruction(const mavis::OpcodeInfo::PtrType & opcode_info)
     {
@@ -48,6 +57,17 @@ namespace olympia
         return false;
     }
 
+    template<class OpInfoListType>
+    OpInfoListType getOpcodeInfoWithRegFileInfo(const Inst::OpInfoList & mavis_opcode_info)
+    {
+        OpInfoListType op_list;
+        for (const auto & op : mavis_opcode_info)
+        {
+            op_list.emplace_back(op);
+        }
+        return op_list;
+    }
+
     /*!
      * \brief Construct an Instruction
      * \param opcode_info    Mavis Opcode information
@@ -61,7 +81,13 @@ namespace olympia
                const InstArchInfo::PtrType & inst_arch_info, const sparta::Clock* clk) :
         opcode_info_(opcode_info),
         inst_arch_info_(inst_arch_info),
+        dest_opcode_info_with_reg_file_(
+            getOpcodeInfoWithRegFileInfo<RenameData::DestOpInfoWithRegfileList>(opcode_info_->getDestOpInfoList())),
+        src_opcode_info_with_reg_file_(
+            getOpcodeInfoWithRegFileInfo<RenameData::SrcOpInfoWithRegfileList>(opcode_info_->getSourceOpInfoList())),
         is_store_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::STORE)),
+        is_load_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::LOAD)),
+        is_move_(opcode_info->isInstTypeAnyOf(mavis::OpcodeInfo::InstructionTypes::MOVE)),
         is_transfer_(miscutils::isOneOf(inst_arch_info_->getTargetPipe(),
                                         InstArchInfo::TargetPipe::I2F,
                                         InstArchInfo::TargetPipe::F2I)),
@@ -71,6 +97,7 @@ namespace olympia
         is_csr_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::CSR)),
         is_return_(isReturnInstruction(opcode_info)),
         has_immediate_(opcode_info_->hasImmediate()),
+        rob_targeted_(getPipe() == InstArchInfo::TargetPipe::ROB),
         is_vector_(opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::VECTOR)),
         is_vector_whole_reg_(
             is_vector_ && opcode_info->isInstType(mavis::OpcodeInfo::InstructionTypes::WHOLE)),
@@ -82,8 +109,8 @@ namespace olympia
 
         // Check that instruction is supported
         sparta_assert(getPipe() != InstArchInfo::TargetPipe::UNKNOWN,
-            "Unknown target pipe (execution) for " << getMnemonic());
+                      "Unknown target pipe (execution) for " << getMnemonic());
         sparta_assert(getExecuteTime() != 0,
-            "Unknown execution time (latency) for " << getMnemonic());
+                      "Unknown execution time (latency) for " << getMnemonic());
     }
 } // namespace olympia

--- a/core/InstArchInfo.cpp
+++ b/core/InstArchInfo.cpp
@@ -31,6 +31,7 @@ namespace olympia
         {"vload", InstArchInfo::TargetPipe::VLOAD},
         {"vstore", InstArchInfo::TargetPipe::VSTORE},
         {"vset", InstArchInfo::TargetPipe::VSET},
+        {"rob", InstArchInfo::TargetPipe::ROB},
         {"sys", InstArchInfo::TargetPipe::SYS},
         {"?", InstArchInfo::TargetPipe::UNKNOWN}};
 
@@ -60,6 +61,7 @@ namespace olympia
         {InstArchInfo::TargetPipe::VLOAD, "VLOAD"},
         {InstArchInfo::TargetPipe::VSTORE, "VSTORE"},
         {InstArchInfo::TargetPipe::VSET, "VSET"},
+        {InstArchInfo::TargetPipe::ROB, "ROB"},
         {InstArchInfo::TargetPipe::SYS, "SYS"},
         {InstArchInfo::TargetPipe::UNKNOWN, "?"}};
 

--- a/core/InstArchInfo.hpp
+++ b/core/InstArchInfo.hpp
@@ -62,6 +62,7 @@ namespace olympia
             VLOAD,
             VSTORE,
             VSET,
+            ROB,
             SYS,
             UNKNOWN
         };

--- a/core/ROB.hpp
+++ b/core/ROB.hpp
@@ -103,7 +103,7 @@ namespace olympia
         sparta::DataOutPort<FlushManager::FlushingCriteria> out_retire_flush_ {&unit_port_set_, "out_retire_flush"};
         // UPDATE:
         sparta::DataOutPort<InstPtr> out_rob_retire_ack_         {&unit_port_set_, "out_rob_retire_ack"};
-        sparta::DataOutPort<InstPtr> out_rob_retire_ack_rename_  {&unit_port_set_, "out_rob_retire_ack_rename"};
+        sparta::DataOutPort<InstGroupPtr> out_rob_retire_ack_rename_  {&unit_port_set_, "out_rob_retire_ack_rename"};
 
         // For flush
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_

--- a/core/RenameData.hpp
+++ b/core/RenameData.hpp
@@ -1,0 +1,153 @@
+// <RenameData.hpp> -*- C++ -*-
+
+#pragma once
+
+#include "mavis/OpcodeInfo.h"
+
+#include "InstArchInfo.hpp"
+#include "CoreTypes.hpp"
+#include "MiscUtils.hpp"
+
+#include <map>
+#include <functional>
+
+#include <boost/container/small_vector.hpp>
+
+namespace olympia
+{
+    static constexpr size_t DEFAULT_NUM_SRCS_ = 2;
+    static constexpr size_t DEFAULT_NUM_DESTS_ = 1;
+
+    class RenameData
+    {
+    public:
+        // Operand information
+        using OpInfoList = mavis::DecodedInstructionInfo::OpInfoList;
+
+        struct OpInfoWithRegfile
+        {
+            OpInfoWithRegfile() = default;
+
+            mavis::OperandInfo::OpcodeFieldValueType field_value =
+                std::numeric_limits<mavis::OperandInfo::OpcodeFieldValueType>::max();
+            mavis::InstMetaData::OperandFieldID field_id =
+                mavis::InstMetaData::OperandFieldID::NONE;
+            core_types::RegFile reg_file = core_types::RegFile::RF_INVALID;
+            bool is_x0 = false;
+
+            OpInfoWithRegfile(const OpInfoList::value_type &);
+        };
+
+        template <size_t DefaultSize>
+        using OpInfoWithRegfileList =
+            boost::container::small_vector<OpInfoWithRegfile, DefaultSize>;
+
+        using SrcOpInfoWithRegfileList = OpInfoWithRegfileList<DEFAULT_NUM_SRCS_>;
+        using DestOpInfoWithRegfileList = OpInfoWithRegfileList<DEFAULT_NUM_DESTS_>;
+
+        // A register consists of its value and its register file.
+        struct Reg
+        {
+            uint32_t phys_reg = 0;
+            uint32_t prev_dest = std::numeric_limits<uint32_t>::max();
+            OpInfoWithRegfile op_info;
+
+            Reg() = default;
+
+            Reg(const uint32_t preg, const OpInfoWithRegfile & opinfo, const uint32_t pv_dest) :
+                phys_reg(preg),
+                prev_dest(pv_dest),
+                op_info(opinfo)
+            {
+            }
+
+            Reg(const uint32_t preg, const OpInfoWithRegfile & opinfo) :
+                Reg(preg, opinfo, std::numeric_limits<uint32_t>::max())
+            {
+            }
+
+            friend inline std::ostream & operator<<(std::ostream & os, const Reg & reg)
+            {
+                os << reg.op_info.reg_file << " " << reg.op_info.field_value << " -> "
+                   << reg.phys_reg;
+
+                if (reg.prev_dest != std::numeric_limits<uint32_t>::max())
+                {
+                    os << " from " << reg.prev_dest;
+                }
+
+                return os;
+            }
+        };
+
+        template <size_t DefaultSize>
+        using RegList = boost::container::small_vector<Reg, DefaultSize>;
+
+        using SrcRegList = RegList<DEFAULT_NUM_SRCS_>;
+        using DestRegList = RegList<DEFAULT_NUM_DESTS_>;
+
+        using SrcRegs = boost::container::small_vector<SrcRegList, core_types::RegFile::N_REGFILES>;
+        using DestRegs =
+            boost::container::small_vector<DestRegList, core_types::RegFile::N_REGFILES>;
+
+        void addSource(const Reg & source)
+        {
+            src_[source.op_info.reg_file].emplace_back(source);
+            ++num_sources_;
+        }
+
+        void addSource(Reg && source)
+        {
+            src_[source.op_info.reg_file].emplace_back(std::forward<Reg>(source));
+            ++num_sources_;
+        }
+
+        const SrcRegList & getSourceList(const core_types::RegFile reg_file) const
+        {
+            return src_[reg_file];
+        }
+
+        uint32_t getNumSources() const { return num_sources_; }
+
+        void addDestination(const Reg & destination)
+        {
+            dest_[destination.op_info.reg_file].emplace_back(destination);
+            ++num_dests_;
+        }
+
+        void addDestination(Reg && destination)
+        {
+            dest_[destination.op_info.reg_file].emplace_back(std::forward<Reg>(destination));
+            ++num_dests_;
+        }
+
+        const DestRegList & getDestList(const core_types::RegFile reg_file) const
+        {
+            return dest_[reg_file];
+        }
+
+        uint32_t getNumDests() const { return num_dests_; }
+
+        // Store data register
+        void setDataReg(Reg && data_reg) { data_reg_ = std::move(data_reg); }
+
+        const Reg & getDataReg() const { return data_reg_; }
+
+        void clear(const core_types::RegFile reg_file)
+        {
+            src_[reg_file].clear();
+            dest_[reg_file].clear();
+            if (data_reg_.op_info.reg_file == reg_file)
+            {
+                data_reg_ = Reg();
+            }
+        }
+
+      private:
+        SrcRegs src_{core_types::RegFile::N_REGFILES};
+        uint32_t num_sources_ = 0;
+        DestRegs dest_{core_types::RegFile::N_REGFILES};
+        uint32_t num_dests_ = 0;
+        Reg data_reg_;
+    };
+} // namespace olympia

--- a/core/dispatch/Dispatch.cpp
+++ b/core/dispatch/Dispatch.cpp
@@ -161,7 +161,12 @@ namespace olympia
         }
         else
         {
-            ILOG("no rob credits or no instructions to process");
+            if(0 == credits_rob_) {
+                ILOG("no rob credits");
+            }
+            else {
+                ILOG("no instructions to process");
+            }
         }
     }
 
@@ -336,4 +341,16 @@ namespace olympia
         dispatch_queue_.clear();
         out_reorder_write_.cancel();
     }
+
+    void Dispatch::dumpDebugContent_(std::ostream & output) const
+    {
+        output << "Dispatch Contents" << std::endl;
+        output << "Current stall: " << current_stall_ << std::endl;
+        output << "Dispatch Queue:" << std::endl;
+        for (const auto & inst : dispatch_queue_)
+        {
+            output <<  inst << std::endl;
+        }
+    }
+
 } // namespace olympia

--- a/core/dispatch/Dispatch.hpp
+++ b/core/dispatch/Dispatch.hpp
@@ -322,6 +322,11 @@ namespace olympia
             "count_lsu_insts + count_mul_insts + count_br_insts"};
 
         friend class DispatchTester;
+
+        // Called when the simulator is shutting down due to an
+        // exception.  Writes out text to aid debug
+        void dumpDebugContent_(std::ostream & output) const override final;
+
     };
 
     using DispatchFactory =

--- a/core/dispatch/Dispatch.hpp
+++ b/core/dispatch/Dispatch.hpp
@@ -150,7 +150,8 @@ namespace olympia
             VLOAD_BUSY = InstArchInfo::TargetPipe::VLOAD,
             VSTORE_BUSY = InstArchInfo::TargetPipe::VSTORE,
             VSET_BUSY = InstArchInfo::TargetPipe::VSET,
-            NO_ROB_CREDITS = InstArchInfo::TargetPipe::SYS, // No credits from the ROB
+            NO_ROB_CREDITS = InstArchInfo::TargetPipe::ROB,
+            SYS_BUSY = InstArchInfo::TargetPipe::SYS, // No credits from the ROB
             NOT_STALLED, // Made forward progress (dispatched all instructions or no instructions)
             N_STALL_REASONS
         };
@@ -213,6 +214,8 @@ namespace olympia
                                   sparta::Counter::COUNT_NORMAL, getClock()),
              sparta::CycleCounter(getStatisticSet(), "stall_rob_full", "No credits from ROB",
                                   sparta::Counter::COUNT_NORMAL, getClock()),
+             sparta::CycleCounter(getStatisticSet(), "sys_busy", "System Unit Busy",
+                                  sparta::Counter::COUNT_NORMAL, getClock()),
              sparta::CycleCounter(getStatisticSet(), "stall_not_stalled",
                                   "Dispatch not stalled, all instructions dispatched",
                                   sparta::Counter::COUNT_NORMAL, getClock())}};
@@ -268,8 +271,11 @@ namespace olympia
                              sparta::Counter::COUNT_NORMAL),
              sparta::Counter(getStatisticSet(), "count_vset_insts", "Total VSET insts",
                              sparta::Counter::COUNT_NORMAL),
+             sparta::Counter(getStatisticSet(), "count_rob_insts", "Total ROB-only insts",
+                             sparta::Counter::COUNT_NORMAL),
              sparta::Counter(getStatisticSet(), "count_sys_insts", "Total SYS insts",
-                             sparta::Counter::COUNT_NORMAL)}};
+                             sparta::Counter::COUNT_NORMAL)
+            }};
 
         // As an example, this is a context counter that does the same
         // thing as the unit_distribution counter, albeit a little

--- a/core/execute/ExecutePipe.cpp
+++ b/core/execute/ExecutePipe.cpp
@@ -81,8 +81,9 @@ namespace olympia
                     // The number of non-tail elements in the uop is used to determine how many
                     // passes are needed
                     const VectorConfigPtr & vector_config = ex_inst->getVectorConfig();
-                    const uint32_t num_elems_per_uop = vector_config->getVLMAX() / vector_config->getLMUL();
-                    const uint32_t num_elems_remaining = \
+                    const uint32_t num_elems_per_uop =
+                        vector_config->getVLMAX() / vector_config->getLMUL();
+                    const uint32_t num_elems_remaining =
                         vector_config->getVL() - (num_elems_per_uop * (ex_inst->getUOpID() - 1));
                     const uint32_t vl = std::min(num_elems_per_uop, num_elems_remaining);
                     const uint32_t num_passes = std::ceil(vl / valu_adder_num_);

--- a/core/execute/ExecutePipe.cpp
+++ b/core/execute/ExecutePipe.cpp
@@ -142,10 +142,11 @@ namespace olympia
                      << " VTA: " << vector_config->getVTA() << " VL: " << vector_config->getVL());
                 out_vset_.send(ex_inst);
             }
-            auto reg_file = ex_inst->getRenameData().getDestination().rf;
-            if (reg_file != core_types::RegFile::RF_INVALID)
+
+            for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
             {
-                const auto & dest_bits = ex_inst->getDestRegisterBitMask(reg_file);
+                const auto & dest_bits =
+                    ex_inst->getDestRegisterBitMask(static_cast<core_types::RegFile>(reg_file));
                 scoreboard_views_[reg_file]->setReady(dest_bits);
             }
 

--- a/core/execute/IssueQueue.cpp
+++ b/core/execute/IssueQueue.cpp
@@ -105,13 +105,15 @@ namespace olympia
             const auto srcs =
                 ex_inst->getRenameData().getSourceList(static_cast<core_types::RegFile>(reg_file));
 
-            if(true == srcs.empty()) { continue; }
+            if (true == srcs.empty())
+            {
+                continue;
+            }
 
             // Lambda function to check if a source is ready.
             // Returns true if source is ready.
             // Returns false and registers a callback if source is not ready.
-            auto check_src_ready = [this, ex_inst](const RenameData::Reg & src,
-                                                   auto reg_file)
+            auto check_src_ready = [this, ex_inst](const RenameData::Reg & src, auto reg_file)
             {
                 // vector-scalar operations have 1 vector src and 1
                 // scalar src that need to be checked, so can't assume
@@ -125,12 +127,10 @@ namespace olympia
                 else
                 {
                     // temporary fix for clearCallbacks not working
-                    scoreboard_views_[reg_file]->registerReadyCallback(src_bits, ex_inst->getUniqueID(),
-                                                                       [this, ex_inst](const sparta::Scoreboard::RegisterBitMask &)
-                                                                       {
-                                                                           this->handleOperandIssueCheck_(ex_inst);
-                                                                       }
-                        );
+                    scoreboard_views_[reg_file]->registerReadyCallback(
+                        src_bits, ex_inst->getUniqueID(),
+                        [this, ex_inst](const sparta::Scoreboard::RegisterBitMask &)
+                        { this->handleOperandIssueCheck_(ex_inst); });
                     return false;
                 }
             };
@@ -141,10 +141,11 @@ namespace olympia
 
                 if (!src_ready)
                 {
-                    ILOG("Instruction NOT ready: " << ex_inst <<
-                         " Bits needed:" << sparta::printBitSet(ex_inst->
-                                                                getSrcRegisterBitMask(static_cast<core_types::RegFile>(reg_file))) <<
-                         " rf: " << reg_file);
+                    ILOG("Instruction NOT ready: "
+                         << ex_inst << " Bits needed:"
+                         << sparta::printBitSet(ex_inst->getSrcRegisterBitMask(
+                                static_cast<core_types::RegFile>(reg_file)))
+                         << " rf: " << static_cast<core_types::RegFile>(reg_file));
                     all_srcs_ready = false;
 
                     // we break to prevent multiple callbacks from

--- a/core/execute/IssueQueue.hpp
+++ b/core/execute/IssueQueue.hpp
@@ -140,8 +140,8 @@ namespace olympia
         friend class IssueQueueTester;
 
         // For correlation activities
-        sparta::pevents::PeventCollector<InstPEventPairs> issue_event_{"ISSUE", getContainer(), getClock()};
-
+        sparta::pevents::PeventCollector<InstPEventPairs> issue_event_{"ISSUE", getContainer(),
+                                                                       getClock()};
     };
 
     using IssueQueueFactory =

--- a/core/rename/Rename.cpp
+++ b/core/rename/Rename.cpp
@@ -1,13 +1,15 @@
+// <Rename.cpp> -*- C++ -*-
+
 /**
- * @file   Rename.cpp
- * @brief
- *
- *
+ * @file  Rename.cpp
+ * @brief Implementation of a simple rename block
  */
 
 #include <algorithm>
+#include <ranges>
+
 #include "CoreUtils.hpp"
-#include "rename/Rename.hpp"
+#include "Rename.hpp"
 #include "sparta/events/StartupEvent.hpp"
 #include "sparta/app/FeatureConfiguration.hpp"
 #include "sparta/report/DatabaseInterface.hpp"
@@ -18,15 +20,18 @@ namespace olympia
 
     Rename::Rename(sparta::TreeNode* node, const RenameParameterSet* p) :
         sparta::Unit(node),
-        uop_queue_("rename_uop_queue", p->rename_queue_depth, node->getClock(), getStatisticSet()),
         num_to_rename_per_cycle_(p->num_to_rename),
+        partial_rename_(p->partial_rename),
+        enable_move_elimination_(p->move_elimination),
         rename_histogram_(*getStatisticSet(), "rename_histogram", "Rename Stage Histogram",
                           [&p]()
                           {
                               std::vector<int> v(p->num_to_rename + 1);
                               std::iota(v.begin(), v.end(), 0);
                               return v;
-                          }())
+                          }()),
+        rename_event_("RENAME", getContainer(), getClock()),
+        uop_queue_("rename_uop_queue", p->rename_queue_depth, node->getClock(), getStatisticSet())
     {
         uop_queue_.enableCollection(node);
 
@@ -40,44 +45,80 @@ namespace olympia
         in_reorder_flush_.registerConsumerHandler(
             CREATE_SPARTA_HANDLER_WITH_DATA(Rename, handleFlush_, FlushManager::FlushingCriteria));
         in_rename_retire_ack_.registerConsumerHandler(
-            CREATE_SPARTA_HANDLER_WITH_DATA(Rename, getAckFromROB_, InstPtr));
-        sparta::StartupEvent(node, CREATE_SPARTA_HANDLER(Rename, setupRename_));
-        auto setup_map = [this](core_types::RegFile reg_file, const uint32_t num_renames)
-        {
-            const uint32_t num_regs = 32; // default risc-v ARF count
-            sparta_assert(num_regs
-                          < num_renames); // ensure we have more renames than 32 because first 32
-                                          // renames are allocated at the beginning
-            // initialize the first 32 Float (31 for INT) regs, i.e x1 -> PRF1
+            CREATE_SPARTA_HANDLER_WITH_DATA(Rename, getAckFromROB_, InstGroupPtr));
 
+        sparta::StartupEvent(node, CREATE_SPARTA_HANDLER(Rename, setupRename_));
+
+        auto setup_map = [this](auto reg_file, uint32_t num_regs_reserved)
+        {
             // for x0 for RF_INTEGER, we don't want to set a PRF for it because x0 is hardwired to 0
-            uint32_t i = 0;
-            if (reg_file == core_types::RegFile::RF_INTEGER)
+            for (uint32_t i = reg_file == core_types::RegFile::RF_INTEGER ? 1 : 0;
+                 i < NUM_RISCV_REGS_; i++)
             {
-                reference_counter_[reg_file].push_back(0);
-                freelist_[reg_file].push(0);
-                i = 1;
+                map_table_[reg_file][i] = num_regs_reserved++;
             }
-            for (; i < num_regs; i++)
-            {
-                map_table_[reg_file][i] = i;
-                // for the first 32 Float (31 INT) registers, we mark their reference_counters 1, as
-                // they are the current "valid" PRF for that ARF
-                reference_counter_[reg_file].push_back(1);
-            }
-            for (uint32_t j = num_regs; j < num_renames; ++j)
-            {
-                freelist_[reg_file].push(j);
-                reference_counter_[reg_file].push_back(0);
-            }
+
+            return num_regs_reserved;
         };
 
-        setup_map(core_types::RegFile::RF_INTEGER, p->num_integer_renames);
-        setup_map(core_types::RegFile::RF_FLOAT, p->num_float_renames);
-        setup_map(core_types::RegFile::RF_VECTOR, p->num_vector_renames);
+        auto setup_freelists =
+            [this](auto reg_file, const uint32_t num_renames, const uint32_t num_regs_reserved)
+            {
+                auto & rcomp = regfile_components_[reg_file];
+                auto & reference_counter = rcomp.reference_counter;
 
-        static_assert(core_types::RegFile::N_REGFILES == 3,
-                      "New RF type added, but Rename not updated");
+                // for x0 for RF_INTEGER, we don't want to set a PRF for it because x0 is hardwired to 0
+                uint32_t i = 0;
+                if (reg_file == core_types::RegFile::RF_INTEGER)
+                {
+                    reference_counter.emplace_back(0);
+                    i = 1;
+                }
+                for (; i < num_regs_reserved; i++)
+                {
+                    // for the first 32 Float (31 INT) registers, we mark
+                    // their reference_counters 1, as they are the current
+                    // "valid" PRF for that ARF.  This can be
+                    // parameterized to NOT do this if running a trace
+                    // that is "bare metal"
+                    reference_counter.emplace_back(1);
+                }
+                for (uint32_t j = num_regs_reserved; j < num_renames; ++j)
+                {
+                    rcomp.freelist.emplace(j);
+                    reference_counter.emplace_back(0);
+                }
+            };
+
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            uint32_t regs_reserved = (reg_file == core_types::RegFile::RF_INTEGER) ? 1 : 0;
+            regs_reserved = setup_map(reg_file, regs_reserved);
+
+            uint32_t num_renames = 0;
+            switch (reg_file)
+            {
+                case core_types::RegFile::RF_INTEGER:
+                    num_renames = p->num_integer_renames;
+                    break;
+                case core_types::RegFile::RF_FLOAT:
+                    num_renames = p->num_float_renames;
+                    break;
+                case core_types::RegFile::RF_VECTOR:
+                    num_renames = p->num_vector_renames;
+                    break;
+                case core_types::RegFile::RF_INVALID:
+                    throw sparta::SpartaException("Invalid register file type.");
+            }
+
+            setup_freelists(reg_file, num_renames, regs_reserved);
+        }
+
+        // This Rename unit might not support all register files, so have to ignore a few params
+        // just in case
+        p->num_integer_renames.ignore();
+        p->num_float_renames.ignore();
+        p->num_vector_renames.ignore();
     }
 
     // Using the Rename factory, create the Scoreboards
@@ -88,12 +129,13 @@ namespace olympia
             sb_tn = new sparta::TreeNode(node, "scoreboards", "Scoreboards used by Rename"));
 
         // Set up the Scoreboard resources
-        for (uint32_t rf = 0; rf < core_types::RegFile::N_REGFILES; ++rf)
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
         {
-            const auto rf_name = core_types::regfile_names[rf];
+            const auto reg_file_name = core_types::regfile_names[reg_file];
             sb_tns_.emplace_back(new sparta::ResourceTreeNode(
-                sb_tn, rf_name, sparta::TreeNode::GROUP_NAME_NONE, sparta::TreeNode::GROUP_IDX_NONE,
-                rf_name + std::string(" Scoreboard"), &sb_facts_[rf]));
+                                     sb_tn, reg_file_name, sparta::TreeNode::GROUP_NAME_NONE,
+                                     sparta::TreeNode::GROUP_IDX_NONE, reg_file_name + std::string(" Scoreboard"),
+                                     &sb_facts_[reg_file]));
         }
     }
 
@@ -102,30 +144,35 @@ namespace olympia
         // Set up scoreboards
         auto sbs_tn = getContainer()->getChild("scoreboards");
         sparta_assert(sbs_tn != nullptr, "Expected to find 'scoreboards' node in Rename, got none");
-        for (uint32_t rf = 0; rf < core_types::RegFile::N_REGFILES; ++rf)
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
         {
             // Get scoreboard resources
-            auto sb_tn = sbs_tn->getChild(core_types::regfile_names[rf]);
-            scoreboards_[rf] = sb_tn->getResourceAs<sparta::Scoreboard*>();
+            auto sb_tn = sbs_tn->getChild(core_types::regfile_names[reg_file]);
+            auto & scoreboard = regfile_components_[reg_file].scoreboard;
+
+            scoreboard = sb_tn->getResourceAs<sparta::Scoreboard*>();
 
             // Initialize 32 scoreboard resources,
             // all ready.
             uint32_t reg = 0;
-            if (rf == core_types::RegFile::RF_INTEGER)
+            if (reg_file == core_types::RegFile::RF_INTEGER)
             {
                 reg = 1;
             }
-            constexpr uint32_t num_regs = 32;
+            const uint32_t num_regs = NUM_RISCV_REGS_;
             core_types::RegisterBitMask bits;
             for (; reg < num_regs; ++reg)
             {
                 bits.set(reg);
             }
-            scoreboards_[rf]->set(bits);
+            scoreboard->set(bits);
         }
 
         // Send the initial credit count
         out_uop_queue_credits_.send(uop_queue_.capacity());
+        stall_counters_[current_stall_].startCounting();
+
+        // ev_sanity_check_.schedule(1);
     }
 
     void Rename::creditsDispatchQueue_(const uint32_t & credits)
@@ -137,398 +184,618 @@ namespace olympia
         {
             ev_schedule_rename_.schedule();
         }
-    }
-
-    void Rename::getAckFromROB_(const InstPtr & inst_ptr)
-    {
-        sparta_assert(inst_ptr->getStatus() == Inst::Status::RETIRED,
-                      "Get ROB Ack, but the inst hasn't retired yet!");
-        auto const & dests = inst_ptr->getDestOpInfoList();
-        if (dests.size() > 0)
-        {
-            sparta_assert(dests.size() == 1); // we should only have one destination
-            const auto dest = dests[0];
-            const auto rf = olympia::coreutils::determineRegisterFile(dest);
-            const auto num = dest.field_value;
-            const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
-            if (!is_x0)
-            {
-                auto const & original_dest = inst_ptr->getRenameData().getOriginalDestination();
-                --reference_counter_[original_dest.rf][original_dest.val];
-                // free previous PRF mapping if no references from srcs, there should be a new dest
-                // mapping for the ARF -> PRF so we know it's free to be pushed to freelist if it
-                // has no other src references
-                if (reference_counter_[original_dest.rf][original_dest.val] <= 0)
-                {
-                    freelist_[original_dest.rf].push(original_dest.val);
-                }
-            }
-        }
-
-        const auto & srcs = inst_ptr->getRenameData().getSourceList();
-        // decrement reference to data register
-        if (inst_ptr->isLoadStoreInst())
-        {
-            const auto & data_reg = inst_ptr->getRenameData().getDataReg();
-            if (data_reg.field_id == mavis::InstMetaData::OperandFieldID::RS2
-                && data_reg.is_x0 != true)
-            {
-                --reference_counter_[data_reg.rf][data_reg.val];
-                if (reference_counter_[data_reg.rf][data_reg.val] <= 0)
-                {
-                    // freeing data register value, because it's not in the source list, so won't
-                    // get caught below
-                    freelist_[data_reg.rf].push(data_reg.val);
-                }
-            }
-        }
-        // freeing references to PRF
-        for (const auto & src : srcs)
-        {
-            --reference_counter_[src.rf][src.val];
-            if (reference_counter_[src.rf][src.val] <= 0)
-            {
-                // freeing a register in the case where it still has references and has already been
-                // retired we wait until the last reference is retired to then free the prf any
-                // "valid" PRF that is the true mapping of an ARF will have a reference_counter of
-                // at least 1, and thus shouldn't be retired
-                freelist_[src.rf].push(src.val);
-            }
-        }
-        // Instruction queue bookkeeping
-        if (SPARTA_EXPECT_TRUE(!inst_queue_.empty()))
-        {
-            const auto & oldest_inst = inst_queue_.front();
-            if (oldest_inst->getUOpID() == 0)
-            {
-                sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(),
-                              "ROB and rename inst_queue out of sync");
-            }
-
-            inst_queue_.pop_front();
-        }
         else
         {
-            sparta_assert(false, "ROB and rename inst_queue out of sync");
+            setStall_(StallReason::NO_DECODE_INSTS);
         }
+        DLOG("credits from dispatch.  Total: " << credits_dispatch_);
+    }
+
+    void Rename::getAckFromROB_(const InstGroupPtr & inst_grp_ptr)
+    {
+        ILOG("Retired instructions: " << inst_grp_ptr);
+
+        auto reclaim_rename = [this](const InstPtr & inst_ptr, const core_types::RegFile reg_file,
+                                     const RenameData::Reg & dest)
+        {
+            if (SPARTA_EXPECT_TRUE(!dest.op_info.is_x0))
+            {
+                const auto prev_dest = dest.prev_dest;
+                sparta_assert(prev_dest != std::numeric_limits<uint32_t>::max());
+                auto & rcomp = regfile_components_[dest.op_info.reg_file];
+                auto & ref = rcomp.reference_counter[prev_dest];
+                sparta_assert(ref.cnt != 0, "reclaim had a 0 ref for " << inst_ptr);
+                DLOG("\t\treclaiming: " << reg_file << " val:" << dest.phys_reg);
+                --ref.cnt;
+                // free previous PRF mapping if no references
+                // from srcs, there should be a new dest
+                // mapping for the ARF -> PRF so we know it's
+                // free to be pushed to freelist if it has no
+                // other src references
+                if (ref.cnt == 0)
+                {
+                    ILOG("\tpushing " << dest.op_info.reg_file << " " << prev_dest
+                         << " on freelist for uid:" << inst_ptr->getUniqueID());
+                    rcomp.freelist.emplace(prev_dest);
+                }
+            }
+        };
+
+        for (const auto & inst_ptr : *inst_grp_ptr)
+        {
+            sparta_assert(inst_ptr->getStatus() == Inst::Status::RETIRED,
+                          "Get ROB Ack, but the inst hasn't retired yet! " << inst_ptr);
+
+            ILOG("\treclaiming: " << inst_ptr);
+
+            for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+            {
+                for (const auto & dest : inst_ptr->getRenameData().getDestList(
+                         static_cast<core_types::RegFile>(reg_file)))
+                {
+                    reclaim_rename(inst_ptr, static_cast<core_types::RegFile>(reg_file), dest);
+                }
+            }
+
+            // FIXME: Let scalar Rename unit do bookkeeping for now
+            if (getContainer()->getGroupIdx() == 0)
+            {
+                sparta_assert(!inst_queue_.empty(), "ROB and rename inst_queue out of sync");
+
+                const auto & oldest_inst = inst_queue_.front();
+                sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(),
+                              "ROB and rename inst_queue out of sync");
+                inst_queue_.pop_front();
+            }
+        }
+
         if (credits_dispatch_ > 0 && (uop_queue_.size() > 0))
         {
             ev_schedule_rename_.schedule();
         }
-        ILOG("Retired instruction: " << inst_ptr);
     }
 
     // Handle incoming flush
     void Rename::handleFlush_(const FlushManager::FlushingCriteria & criteria)
     {
         ILOG("Got a flush call for " << criteria);
-        // Restore the rename map, reference counters and freelist by walking through the inst_queue
-        while (inst_queue_.size())
+
+        // Restore the rename map, reference counters and freelist by walking through the
+        // inst_queue_ inst_queue_.erase((++it).base()) will advance the reverse_iterator and then
+        // erase the element it previously pointed to. it remains valid because we're erasing from
+        // the back of the deque
+        for (auto it = inst_queue_.rbegin(); it != inst_queue_.rend();
+             inst_queue_.erase((++it).base()))
         {
-            const auto & inst_ptr = inst_queue_.back();
+            const auto & inst_ptr = *it;
             if (!criteria.includedInFlush(inst_ptr))
             {
-                break;
+                ILOG("\t" << inst_ptr << " not included in flush ")
+                    break;
             }
             else
             {
-                auto const & dests = inst_ptr->getDestOpInfoList();
-                for (const auto & dest : dests)
-                {
-                    // restore rename table following a flush
-                    const auto rf = olympia::coreutils::determineRegisterFile(dest);
-                    const auto num = dest.field_value;
-                    const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
-                    if (!is_x0)
-                    {
-                        auto const & original_dest =
-                            inst_ptr->getRenameData().getOriginalDestination();
-                        map_table_[rf][num] = original_dest.val;
+                ILOG("\treclaiming: " << inst_ptr);
 
-                        // free renamed PRF mapping when reference counter reaches zero
-                        auto const & renamed_dest = inst_ptr->getRenameData().getDestination();
-                        --reference_counter_[renamed_dest.rf][renamed_dest.val];
-                        if (reference_counter_[renamed_dest.rf][renamed_dest.val] <= 0)
+                for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+                {
+                    auto const & dests = inst_ptr->getRenameData().getDestList(
+                        static_cast<core_types::RegFile>(reg_file));
+                    for (const auto & dest : dests)
+                    {
+                        // restore rename table following a flush
+                        if (!dest.op_info.is_x0)
                         {
-                            freelist_[renamed_dest.rf].push(renamed_dest.val);
+                            map_table_[dest.op_info.reg_file][dest.op_info.field_value] =
+                                dest.prev_dest;
+
+                            // free renamed PRF mapping when reference counter reaches zero
+                            ILOG("\t\treclaiming: " << dest.op_info.reg_file
+                                 << " val:" << dest.phys_reg);
+                            auto & rcomp = regfile_components_[dest.op_info.reg_file];
+                            auto & ref = rcomp.reference_counter[dest.phys_reg];
+                            sparta_assert(ref.cnt != 0, "reclaim had a 0 ref for " << inst_ptr);
+                            --ref.cnt;
+                            if (ref.cnt == 0)
+                            {
+                                sparta_assert(dest.op_info.reg_file
+                                              != core_types::RegFile::RF_INVALID);
+                                rcomp.freelist.emplace(dest.phys_reg);
+                            }
                         }
                     }
-                }
 
-                const auto & srcs = inst_ptr->getRenameData().getSourceList();
-                // decrement reference to data register
-                if (inst_ptr->isLoadStoreInst())
-                {
-                    const auto & data_reg = inst_ptr->getRenameData().getDataReg();
-                    if (data_reg.field_id == mavis::InstMetaData::OperandFieldID::RS2
-                        && data_reg.is_x0 != true)
-                    {
-                        --reference_counter_[data_reg.rf][data_reg.val];
-                        if (reference_counter_[data_reg.rf][data_reg.val] <= 0)
-                        {
-                            // freeing data register value, because it's not in the source list, so
-                            // won't get caught below
-                            freelist_[data_reg.rf].push(data_reg.val);
-                        }
-                    }
+                    inst_ptr->getRenameData().clear(static_cast<core_types::RegFile>(reg_file));
                 }
-                // freeing references to PRF
-                for (const auto & src : srcs)
-                {
-                    --reference_counter_[src.rf][src.val];
-                    if (reference_counter_[src.rf][src.val] <= 0)
-                    {
-                        // freeing a register in the case where it still has references and has
-                        // already been retired we wait until the last reference is retired to then
-                        // free the prf any "valid" PRF that is the true mapping of an ARF will have
-                        // a reference_counter of at least 1, and thus shouldn't be retired
-                        freelist_[src.rf].push(src.val);
-                    }
-                }
-                inst_queue_.pop_back();
             }
         }
 
-        current_stall_ = NO_DECODE_INSTS;
-
-        // Clean up buffers
-        uop_queue_regcount_data_.clear();
-        out_uop_queue_credits_.send(uop_queue_.size());
-        uop_queue_.clear();
+        setStall_(NO_DECODE_INSTS);
+        if (false == uop_queue_.empty())
+        {
+            out_uop_queue_credits_.send(uop_queue_.size());
+            uop_queue_.clear();
+        }
     }
 
     void Rename::decodedInstructions_(const InstGroupPtr & insts)
     {
-        sparta_assert(in_uop_queue_append_.dataReceived());
-
-        RegCountData current_counts;
-        if (!uop_queue_regcount_data_.empty())
-        {
-            // if we have entries, use the most recent entered instruction counts
-            current_counts = uop_queue_regcount_data_.back();
-        }
         for (auto & i : *insts)
         {
-            // create an index count for each instruction entered
-            const auto & dests = i->getDestOpInfoList();
-            if (dests.size() > 0)
+            DLOG("Received inst: " << i);
+            uop_queue_.push_back(i);
+        }
+        updateRegcountData_();
+        ev_schedule_rename_.schedule();
+    }
+
+    void Rename::updateRegcountData_()
+    {
+        // Clear the data
+        uop_queue_regcount_data_ = RegCountData();
+
+        if (false == uop_queue_.empty())
+        {
+            for (const auto & inst : uop_queue_)
             {
-                sparta_assert(dests.size() == 1); // we should only have one destination
-                const auto rf = olympia::coreutils::determineRegisterFile(dests[0]);
-                const auto num = dests[0].field_value;
-                const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
-                // if dest is x0, we don't need to count it towards cumulative register count
-                if (!is_x0)
+                // create an index count for each instruction entered
+                const auto & dests = inst->getDestOpInfoListWithRegfile();
+                for (const auto & dest : dests)
                 {
-                    current_counts.cumulative_reg_counts[rf]++;
+                    const auto reg_file = dest.reg_file;
+                    // if dest is x0, we don't need to count it towards
+                    // cumulative register count
+                    if (false == dest.is_x0)
+                    {
+                        ++uop_queue_regcount_data_.cumulative_reg_counts[reg_file];
+                    }
+                }
+                if (partial_rename_)
+                {
+                    // just need to update register counts for the
+                    // first instruction in the queue
+                    break;
                 }
             }
-            uop_queue_.push(i);
-            uop_queue_regcount_data_.push_back(current_counts);
         }
+    }
 
-        if (credits_dispatch_ > 0)
+    std::pair<bool, Rename::StallReason> Rename::enoughRenames_() const
+    {
+        // Determine if rename has enough destination renames to
+        // rename this instruction.
+        bool enough_renames = true;
+
+        static constexpr StallReason stall_reason_map[core_types::RegFile::N_REGFILES] = {
+            StallReason::NO_INTEGER_RENAMES,
+            StallReason::NO_FLOAT_RENAMES,
+            StallReason::NO_VECTOR_RENAMES,
+        };
+
+        StallReason stall_reason = StallReason::NOT_STALLED;
+
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
         {
-            ev_schedule_rename_.schedule();
+            if (uop_queue_regcount_data_.cumulative_reg_counts[reg_file]
+                > regfile_components_[reg_file].freelist.size())
+            {
+                enough_renames = false;
+                stall_reason = stall_reason_map[reg_file];
+                break;
+            }
         }
+        return {enough_renames, stall_reason};
     }
 
     void Rename::scheduleRenaming_()
     {
-        current_stall_ = StallReason::NOT_STALLED;
+        setStall_(StallReason::NOT_STALLED);
 
-        // If we have credits from dispatch, schedule a rename session this cycle
-        uint32_t num_rename = std::min(uop_queue_.size(), num_to_rename_per_cycle_);
-        num_rename = std::min(credits_dispatch_, num_rename);
-        if (credits_dispatch_ > 0)
+        const auto disp_size = uop_queue_.size();
+
+        if (disp_size == 0)
         {
-            RegCountData count_subtract;
-            bool enough_rename = false;
-            for (uint32_t i = num_rename; i > 0; --i)
+            setStall_(NO_DECODE_INSTS);
+            return;
+        }
+
+        bool have_dispatch_credits = false;
+        if (false == partial_rename_)
+        {
+            // If we're not doing partial renaming, we need full BW
+            // from dispatch.
+            if (credits_dispatch_ < disp_size)
             {
-                if (enough_rename)
-                {
-                    // once we know the number we can rename
-                    // pop everything below it
-                    uop_queue_regcount_data_.pop_front();
-                }
-                else
-                {
-                    uint32_t enough_freelists = 0;
-                    for (int j = 0; j < core_types::RegFile::N_REGFILES; ++j)
-                    {
-                        if (uop_queue_regcount_data_[i - 1].cumulative_reg_counts[j]
-                            <= freelist_[j].size())
-                        {
-                            enough_freelists++;
-                        }
-                    }
-                    if (enough_freelists == core_types::RegFile::N_REGFILES)
-                    {
-                        // we are good to process all instructions from this index
-                        num_to_rename_ = i;
-                        enough_rename = true;
-                    }
-                }
-            }
-            // decrement the rest of the entries in the uop_queue_reg_count_data_ accordingly
-            if (enough_rename)
-            {
-                count_subtract = uop_queue_regcount_data_.front();
-                uop_queue_regcount_data_.pop_front();
-                for (uint32_t i = 0; i < uop_queue_regcount_data_.size(); ++i)
-                {
-                    for (uint32_t j = 0; j < core_types::RegFile::N_REGFILES; ++j)
-                    {
-                        uop_queue_regcount_data_[i].cumulative_reg_counts[j] -=
-                            count_subtract.cumulative_reg_counts[j];
-                    }
-                }
-                ev_rename_insts_.schedule();
+                DLOG("not enough disp credits");
+                setStall_(StallReason::NO_DISPATCH_CREDITS);
             }
             else
             {
-                current_stall_ = StallReason::NO_RENAMES;
-                num_to_rename_ = 0;
+                have_dispatch_credits = true;
             }
         }
         else
         {
-            current_stall_ = StallReason::NO_DISPATCH_CREDITS;
-            num_to_rename_ = 0;
+            have_dispatch_credits = (credits_dispatch_ > 0);
         }
-        ILOG("current stall: " << current_stall_);
 
-        rename_histogram_.addValue((int)num_to_rename_);
+        // If we have credits from dispatch.  If so schedule a rename
+        // session this cycle if we have enough Renames for at least
+        // the oldest instruction in Rename
+        if (have_dispatch_credits)
+        {
+            const auto [enough_renames, stalled_regfile] = enoughRenames_();
+            if (enough_renames)
+            {
+                ev_rename_insts_.schedule();
+            }
+            else
+            {
+                DLOG("not enough renames");
+                setStall_(stalled_regfile);
+            }
+        }
+        else
+        {
+            if (0 == credits_dispatch_)
+            {
+                setStall_(StallReason::NO_DISPATCH_CREDITS);
+            }
+        }
+        ILOG("current stall: " << getStall_());
     }
 
     void Rename::renameInstructions_()
     {
-        if (num_to_rename_ > 0)
+        // Pick instructions from uop queue to rename
+        InstGroupPtr insts = sparta::allocate_sparta_shared_pointer<InstGroup>(instgroup_allocator);
+
+        uint32_t num_to_rename = std::min(uop_queue_.size(), num_to_rename_per_cycle_);
+        num_to_rename = std::min(credits_dispatch_, num_to_rename);
+
+        sparta_assert(num_to_rename > 0,
+                      "Not sure why we're renaming if there are no credits and/or no insts");
+        do
         {
-            // Pick instructions from uop queue to rename
-            InstGroupPtr insts =
-                sparta::allocate_sparta_shared_pointer<InstGroup>(instgroup_allocator);
+            const auto & inst_to_rename = uop_queue_.access(0);
 
-            for (uint32_t i = 0; i < num_to_rename_; ++i)
+            ILOG("Renaming " << inst_to_rename);
+
+            if (partial_rename_)
             {
-                // Pick the oldest
-                const auto & renaming_inst = uop_queue_.read(0);
-                renaming_inst->setStatus(Inst::Status::RENAMED);
-                ILOG("sending inst to dispatch: " << renaming_inst);
-
-                const auto & srcs = renaming_inst->getSourceOpInfoList();
-                const auto & dests = renaming_inst->getDestOpInfoList();
-                for (const auto & src : srcs)
+                const auto [enough_renames, stalled_regfile] = enoughRenames_();
+                if (false == enough_renames)
                 {
-                    const auto rf = olympia::coreutils::determineRegisterFile(src);
-                    const auto num = src.field_value;
-                    // we check if src is RF_INTEGER x0, if so, we skip rename
-                    const bool is_x0 = (num == 0 && rf == core_types::RF_INTEGER);
-                    if (is_x0)
-                    {
-                        // if x0 is a data operand for LSU op, we need to set it in DataReg when we
-                        // check in LSU so we can still check the scoreboard, which will always
-                        // return back ready for x0
-                        if (src.field_id == mavis::InstMetaData::OperandFieldID::RS2)
-                        {
-                            renaming_inst->getRenameData().setDataReg(
-                                {num, rf, src.field_id, is_x0});
-                        }
-                        continue;
-                    }
-                    // we check for load/store separately because address operand
-                    // is always integer
-                    else if (renaming_inst->isLoadStoreInst())
-                    {
-                        // check for data operand existing based on RS2 existence
-                        // store data register info separately
-                        if (src.field_id == mavis::InstMetaData::OperandFieldID::RS2)
-                        {
-                            auto & bitmask = renaming_inst->getDataRegisterBitMask(rf);
-                            const uint32_t prf = map_table_[rf][num];
-                            reference_counter_[rf][prf]++;
-                            renaming_inst->getRenameData().setDataReg(
-                                {prf, rf, src.field_id, is_x0});
-                            bitmask.set(prf);
-
-                            ILOG("\tsetup store data register bit mask " << sparta::printBitSet(
-                                     bitmask) << " for '" << rf << "' scoreboard");
-                        }
-                        else
-                        {
-                            // address is always INTEGER
-                            const auto addr_rf = core_types::RF_INTEGER;
-                            auto & bitmask = renaming_inst->getSrcRegisterBitMask(addr_rf);
-                            const uint32_t prf = map_table_[addr_rf][num];
-                            reference_counter_[addr_rf][prf]++;
-                            renaming_inst->getRenameData().setSource({prf, addr_rf, src.field_id});
-                            bitmask.set(prf);
-
-                            ILOG("\tsetup source register bit mask " << sparta::printBitSet(
-                                     bitmask) << " for '" << addr_rf << "' scoreboard");
-                        }
-                    }
-                    else
-                    {
-                        auto & bitmask = renaming_inst->getSrcRegisterBitMask(rf);
-                        const uint32_t prf = map_table_[rf][num];
-                        reference_counter_[rf][prf]++;
-                        renaming_inst->getRenameData().setSource({prf, rf, src.field_id});
-                        bitmask.set(prf);
-
-                        ILOG("\tsetup source register bit mask "
-                             << sparta::printBitSet(bitmask) << " for '" << rf << "' scoreboard");
-                    }
+                    setStall_(stalled_regfile);
+                    ILOG("\tStall: Not enough renames " << inst_to_rename);
+                    break;
                 }
-
-                for (const auto & dest : dests)
-                {
-                    const auto rf = olympia::coreutils::determineRegisterFile(dest);
-                    const auto num = dest.field_value;
-                    if (num == 0 && rf == core_types::RF_INTEGER)
-                    {
-                        continue;
-                    }
-                    else
-                    {
-                        auto & bitmask = renaming_inst->getDestRegisterBitMask(rf);
-                        const uint32_t prf = freelist_[rf].front();
-                        freelist_[rf].pop();
-                        renaming_inst->getRenameData().setOriginalDestination(
-                            {map_table_[rf][num], rf, dest.field_id});
-                        renaming_inst->getRenameData().setDestination({prf, rf, dest.field_id});
-                        map_table_[rf][num] = prf;
-                        // we increase reference_counter_ for destinations to mark them as "valid",
-                        // so the PRF in the reference_counter_ should have a value of 1
-                        // once a PRF reference_counter goes to 0, we know that the PRF isn't the
-                        // "valid" PRF for that ARF anymore and there are no sources referring to it
-                        // so we can push it to freelist
-                        reference_counter_[rf][prf]++;
-                        bitmask.set(prf);
-                        // clear scoreboard for the PRF we are allocating
-                        scoreboards_[rf]->clearBits(bitmask);
-                        ILOG("\tsetup destination register bit mask "
-                             << sparta::printBitSet(bitmask) << " for '" << rf << "' scoreboard");
-                    }
-                }
-                // Remove it from uop queue
-                insts->emplace_back(renaming_inst);
-                inst_queue_.emplace_back(renaming_inst);
-                uop_queue_.pop();
             }
 
-            // Send insts to dispatch
+            // Rename the instruction
+            renameSources_(inst_to_rename);
+            renameDests_(inst_to_rename);
+            inst_to_rename->setStatus(Inst::Status::RENAMED);
+            insts->emplace_back(std::move(uop_queue_.access(0)));
+
+            // Remove it from uop queue
+            uop_queue_.erase(0);
+
+            // FIXME: Let scalar Rename unit do bookkeeping for now
+            if (getContainer()->getGroupIdx() == 0)
+            {
+                inst_queue_.emplace_back(inst_to_rename);
+            }
+            rename_event_.collect(*inst_to_rename);
+
+            if (partial_rename_)
+            {
+                if (false == uop_queue_.empty())
+                {
+                    updateRegcountData_();
+                }
+            }
+
+            --num_to_rename;
+
+        } while (num_to_rename != 0);
+
+        if (false == partial_rename_)
+        {
+            sparta_assert(num_to_rename == 0,
+                          "Still have instructions to rename, but we're not partial to that. HA!");
+            sparta_assert(uop_queue_.empty(), "How is the uop queue not empty?")
+                }
+
+        if (false == insts->empty())
+        {
+            const uint32_t num_renamed = insts->size();
+            // Send insts to dispatch that were renamed
+            ILOG("sending insts to dispatch: " << insts);
             out_dispatch_queue_write_.send(insts);
-            credits_dispatch_ -= num_to_rename_;
+            credits_dispatch_ -= num_renamed;
 
             // Replenish credits in the Decode unit
-            out_uop_queue_credits_.send(num_to_rename_);
-            num_to_rename_ = 0;
+            out_uop_queue_credits_.send(num_renamed);
+            rename_histogram_.addValue(num_renamed);
         }
+
         if (credits_dispatch_ > 0 && (uop_queue_.size() > 0))
         {
             ev_schedule_rename_.schedule(1);
         }
+        else if (credits_dispatch_ == 0)
+        {
+            setStall_(StallReason::NO_DISPATCH_CREDITS);
+        }
+        else
+        {
+            setStall_(StallReason::NO_DECODE_INSTS);
+        }
     }
+
+    void Rename::renameSources_(const InstPtr & renaming_inst)
+    {
+        const auto & srcs = renaming_inst->getSrcOpInfoListWithRegfile();
+        for (const auto & src : srcs)
+        {
+            const auto reg_file = src.reg_file;
+            const auto arch_num = src.field_value;
+            const bool is_x0 = src.is_x0;
+            const bool is_rs2 = src.field_id == mavis::InstMetaData::OperandFieldID::RS2;
+            const bool is_rs3 = src.field_id == mavis::InstMetaData::OperandFieldID::RS3;
+
+            // we check if src is RF_INTEGER x0, if so, we skip rename
+            if (is_x0)
+            {
+                // if x0 is a data operand for LSU agen, we need to
+                // set it in DataReg when we check in LSU so we can
+                // still check the scoreboard, which will always
+                // return back ready for x0
+                if (is_rs2)
+                {
+                    renaming_inst->setDataRegister({arch_num, src});
+                }
+                continue;
+            }
+
+            const uint32_t prf = map_table_[reg_file][arch_num];
+
+            // For load/store, check if producing inst was a load
+            if (renaming_inst->isLoadStoreInst())
+            {
+                auto & rcomp = regfile_components_[reg_file];
+                auto & reference_counter = rcomp.reference_counter[prf];
+                if (reference_counter.producer_is_load)
+                {
+                    renaming_inst->setLoadProducer(true);
+                    DLOG("Renaming ld/st that has a load producer: " << renaming_inst);
+                }
+            }
+
+            // we check for load/store separately because address
+            // operand is always integer
+            if ((is_rs2 || is_rs3) && renaming_inst->isLoadStoreInst())
+            {
+                renaming_inst->setDataRegister({prf, src});
+                ILOG("\tls data rename " << arch_num << " -> " << prf);
+                continue;
+            }
+
+            ILOG("\tsource rename " << reg_file << " " << arch_num << " -> " << prf);
+            renaming_inst->addSrcRegister({prf, src});
+        }
+    }
+
+    void Rename::renameDests_(const InstPtr & renaming_inst)
+    {
+        const auto & dests = renaming_inst->getDestOpInfoListWithRegfile();
+        for (const auto & dest : dests)
+        {
+            const auto reg_file = dest.reg_file;
+            const auto arch_num = dest.field_value;
+            const bool is_x0 = dest.is_x0;
+
+            if (false == is_x0)
+            {
+                auto & rcomp = regfile_components_[reg_file];
+                auto & freelist = rcomp.freelist;
+
+                sparta_assert(!freelist.empty(), "Freelist should never be empty");
+
+                uint32_t prf = 0;
+                bool update_scoreboard = true;
+
+                bool move_eliminated = false;
+                if (enable_move_elimination_ && renaming_inst->isMove())
+                {
+                    // Get the source PRF
+                    const auto & src_list = renaming_inst->getRenameData().getSourceList(reg_file);
+
+                    // Check for FP move operations that have 2
+                    // source operands.  These are short hand fmv
+                    // operations: fsgnj rx, ry, ry
+                    if (src_list.size() > 1)
+                    {
+                        sparta_assert(
+                            src_list[0].phys_reg == src_list[0].phys_reg,
+                            "MOV inst with 2 sources are not equivalent: " << renaming_inst);
+                    }
+
+                    // Check for moves from 1 register file type to
+                    // another.  Can't do that.  In this case, the
+                    // source list will be empty for that register
+                    // file type
+                    if (false == src_list.empty())
+                    {
+                        prf = src_list[0].phys_reg;
+                        renaming_inst->setTargetROB();
+                        ILOG("\tMove elim: mapping " << arch_num << " to " << prf);
+                        update_scoreboard = false;
+                        ++move_eliminations_;
+                        move_eliminated = true;
+                    }
+                }
+
+                if (SPARTA_EXPECT_TRUE(false == move_eliminated))
+                {
+                    prf = freelist.front();
+                    DLOG("popping: " << prf);
+                    freelist.pop();
+                }
+
+                const uint32_t prev_dest = map_table_[reg_file][arch_num];
+                RenameData::Reg renamed_dst({prf, dest, prev_dest});
+
+                map_table_[reg_file][arch_num] = prf;
+
+                // we increase reference_counter_ for destinations to mark them as "valid",
+                // so the PRF in the reference_counter_ should have a value of 1
+                // once a PRF reference_counter goes to 0, we know that the PRF isn't the
+                // "valid" PRF for that ARF anymore and there are no sources referring to it
+                // so we can push it to freelist
+                auto & reference_counter = rcomp.reference_counter[renamed_dst.phys_reg];
+                ++reference_counter.cnt;
+                reference_counter.producer_id = renaming_inst->getUniqueID();
+                reference_counter.producer = renaming_inst;
+                reference_counter.producer_is_load = renaming_inst->isLoadInst();
+                ILOG("\tdest rename " << renamed_dst);
+                if (SPARTA_EXPECT_TRUE(update_scoreboard))
+                {
+                    renaming_inst->addDestRegisterWithScoreboardUpdate(
+                        std::forward<RenameData::Reg>(renamed_dst),
+                        regfile_components_[reg_file].scoreboard);
+                }
+                else
+                {
+                    renaming_inst->addDestRegister(std::forward<RenameData::Reg>(renamed_dst));
+                }
+            }
+        }
+    }
+
+    void Rename::sanityCheck_()
+    {
+        // Check for duplications in the freelist
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            const auto & rcomp = regfile_components_[reg_file];
+            if (false == rcomp.freelist.empty())
+            {
+                std::vector<uint32_t> sorted_fl;
+                // copy
+                auto flq = rcomp.freelist;
+                while (false == flq.empty())
+                {
+                    sorted_fl.emplace_back(flq.back());
+                    flq.pop();
+                }
+                std::sort(sorted_fl.begin(), sorted_fl.end());
+                uint32_t reg = sorted_fl.front();
+                auto next_reg = sorted_fl.begin();
+                ++next_reg;
+                while (next_reg != sorted_fl.end())
+                {
+                    sparta_assert(reg != *next_reg,
+                                  "Duplicate reg " << reg << " in regfile " << reg_file);
+                    reg = *next_reg;
+                }
+            }
+        }
+
+        ev_sanity_check_.schedule(1);
+    }
+
+    template <class OStreamT> void Rename::dumpRenameContent_(OStreamT & output) const
+    {
+        output << "Rename Contents" << std::endl;
+        output << "\tcurrent stall: " << current_stall_ << std::endl;
+        output << "\tdisp credits: " << credits_dispatch_ << std::endl;
+        output << "\tUop Queue" << std::endl;
+        for (const auto & inst : uop_queue_)
+        {
+            output << "\t\t" << inst << " S_INT"
+                   << sparta::printBitSet(
+                       inst->getSrcRegisterBitMask(core_types::RegFile::RF_INTEGER))
+                   << " S_DAT"
+                   << sparta::printBitSet(
+                       inst->getDataRegisterBitMask(core_types::RegFile::RF_INTEGER))
+                   << " D_INT"
+                   << sparta::printBitSet(
+                       inst->getDestRegisterBitMask(core_types::RegFile::RF_INTEGER))
+                   << std::endl;
+        }
+        output << "\n\toutstanding insts (waiting for retire)" << std::endl;
+        for (const auto & inst : inst_queue_)
+        {
+            output << "\t\t" << inst << std::endl;
+        }
+        output << "\n\trename maps" << std::endl;
+
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            output << "\t\t" << core_types::regfile_names[reg_file] << ": map table:" << std::endl;
+            const auto & reg_array = map_table_[reg_file];
+            const auto & ref_counts = regfile_components_[reg_file].reference_counter;
+            for (uint32_t reg = 0; reg < NUM_RISCV_REGS_; ++reg)
+            {
+                const auto & ref_count_ref = ref_counts.at(reg_array[reg]);
+                output << "\t\t\t" << std::setw(2) << reg << " -> " << std::setw(3)
+                       << reg_array[reg] << " refc: " << std::setw(2) << ref_count_ref.cnt
+                       << " prod: " << std::setw(8) << ref_count_ref.producer_id << " ";
+                if (ref_count_ref.producer.expired())
+                {
+                    output << "<inst retired>";
+                }
+                else
+                {
+                    output << ref_count_ref.producer.lock();
+                }
+                output << std::endl;
+            }
+        }
+
+        // Cumulative counts
+        output << "Cumulative reg counts for current uop queue:";
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            output << "\n\t" << reg_file << " "
+                   << uop_queue_regcount_data_.cumulative_reg_counts[reg_file];
+        }
+
+        output << "\nfree lists";
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            output << "\n\t" << core_types::regfile_names[reg_file] << ":";
+            char comma = ' ';
+            auto fln = regfile_components_[reg_file].freelist;
+            while (false == fln.empty())
+            {
+                output << comma << fln.front();
+                comma = ',';
+                fln.pop();
+            }
+        }
+        output << "\nref cnts:";
+        for (auto reg_file = 0; reg_file < core_types::RegFile::N_REGFILES; ++reg_file)
+        {
+            output << "\n\t" << core_types::regfile_names[reg_file] << ":";
+            auto ref_cnts = regfile_components_[reg_file].reference_counter;
+
+            for (uint32_t idx = 0; idx < ref_cnts.size(); ++idx)
+            {
+                output << "\n\t\t" << idx << ": " << ref_cnts[idx].cnt;
+            }
+        }
+        output << std::endl;
+    }
+
+    void Rename::dumpDebugContent_(std::ostream & output) const { dumpRenameContent_(output); }
+
+    void Rename::dumpDebugContentHearbeat_()
+    {
+        dumpRenameContent_(info_logger_);
+        ev_debug_rename_.schedule(1);
+    }
+
 } // namespace olympia

--- a/core/rename/Rename.cpp
+++ b/core/rename/Rename.cpp
@@ -237,16 +237,12 @@ namespace olympia
                 }
             }
 
-            // FIXME: Let scalar Rename unit do bookkeeping for now
-            if (getContainer()->getGroupIdx() == 0)
-            {
-                sparta_assert(!inst_queue_.empty(), "ROB and rename inst_queue out of sync");
+            sparta_assert(!inst_queue_.empty(), "ROB and rename inst_queue out of sync");
 
-                const auto & oldest_inst = inst_queue_.front();
-                sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(),
-                              "ROB and rename inst_queue out of sync");
-                inst_queue_.pop_front();
-            }
+            const auto & oldest_inst = inst_queue_.front();
+            sparta_assert(oldest_inst->getUniqueID() == inst_ptr->getUniqueID(),
+                          "ROB and rename inst_queue out of sync");
+            inst_queue_.pop_front();
         }
 
         if (credits_dispatch_ > 0 && (uop_queue_.size() > 0))
@@ -260,10 +256,12 @@ namespace olympia
     {
         ILOG("Got a flush call for " << criteria);
 
-        // Restore the rename map, reference counters and freelist by walking through the
-        // inst_queue_ inst_queue_.erase((++it).base()) will advance the reverse_iterator and then
-        // erase the element it previously pointed to. it remains valid because we're erasing from
-        // the back of the deque
+        // Restore the rename map, reference counters and freelist by
+        // walking through the inst_queue_
+        // inst_queue_.erase((++it).base()) will advance the
+        // reverse_iterator and then erase the element it previously
+        // pointed to. it remains valid because we're erasing from the
+        // back of the deque
         for (auto it = inst_queue_.rbegin(); it != inst_queue_.rend();
              inst_queue_.erase((++it).base()))
         {
@@ -481,11 +479,7 @@ namespace olympia
             // Remove it from uop queue
             uop_queue_.erase(0);
 
-            // FIXME: Let scalar Rename unit do bookkeeping for now
-            if (getContainer()->getGroupIdx() == 0)
-            {
-                inst_queue_.emplace_back(inst_to_rename);
-            }
+            inst_queue_.emplace_back(inst_to_rename);
             rename_event_.collect(*inst_to_rename);
 
             if (partial_rename_)

--- a/core/rename/Rename.hpp
+++ b/core/rename/Rename.hpp
@@ -1,4 +1,14 @@
-// <Rename.h> -*- C++ -*-
+// <Rename.hpp> -*- C++ -*-
+
+/**
+ * @file   Rename.hpp
+ * @brief
+ *
+ * Rename will
+ * 1. Create the rename uop queue
+ * 2. Rename the uops and send to dispatch pipe (retrieved via port)
+ * 3. The dispatch pipe will send to unit for schedule
+ */
 
 #pragma once
 
@@ -10,10 +20,11 @@
 #include "sparta/simulation/TreeNode.hpp"
 #include "sparta/simulation/ParameterSet.hpp"
 #include "sparta/simulation/ResourceFactory.hpp"
-#include "sparta/resources/Scoreboard.hpp"
 #include "sparta/utils/SpartaTester.hpp"
 #include "sparta/statistics/Histogram.hpp"
 #include "sparta/statistics/BasicHistogram.hpp"
+#include "sparta/pevents/PeventCollector.hpp"
+#include "sparta/resources/Scoreboard.hpp"
 
 #include "CoreTypes.hpp"
 #include "FlushManager.hpp"
@@ -33,18 +44,21 @@ namespace olympia
      */
     class Rename : public sparta::Unit
     {
-      public:
+    public:
         //! \brief Parameters for Rename model
         class RenameParameterSet : public sparta::ParameterSet
         {
-          public:
+        public:
             RenameParameterSet(sparta::TreeNode* n) : sparta::ParameterSet(n) {}
 
             PARAMETER(uint32_t, num_to_rename, 4, "Number of instructions to rename")
             PARAMETER(uint32_t, rename_queue_depth, 10, "Number of instructions queued for rename")
             PARAMETER(uint32_t, num_integer_renames, 128, "Number of integer renames")
             PARAMETER(uint32_t, num_float_renames, 128, "Number of float renames")
-            PARAMETER(uint32_t, num_vector_renames, 48, "Number of vector renames")
+            PARAMETER(uint32_t, num_vector_renames, 128, "Number of vector renames")
+            PARAMETER(bool, partial_rename, true,
+                      "Rename all or partial instructions in a received group")
+            PARAMETER(bool, move_elimination, false, "Enable move elimination")
         };
 
         /**
@@ -58,72 +72,95 @@ namespace olympia
         //! \brief Name of this resource. Required by sparta::UnitFactory
         static const char name[];
 
-      private:
-        InstQueue uop_queue_;
+    private:
+        static constexpr uint32_t NUM_RISCV_REGS_ = 32; // default risc-v ARF count
+
+        const uint32_t num_to_rename_per_cycle_;
+        const bool partial_rename_;
+        const bool enable_move_elimination_;
+
         sparta::DataInPort<InstGroupPtr> in_uop_queue_append_{&unit_port_set_,
-                                                              "in_uop_queue_append", 1};
+            "in_uop_queue_append", 1};
         sparta::DataOutPort<uint32_t> out_uop_queue_credits_{&unit_port_set_,
-                                                             "out_uop_queue_credits"};
+            "out_uop_queue_credits"};
         sparta::DataOutPort<InstGroupPtr> out_dispatch_queue_write_{&unit_port_set_,
-                                                                    "out_dispatch_queue_write"};
+            "out_dispatch_queue_write"};
         sparta::DataInPort<uint32_t> in_dispatch_queue_credits_{
             &unit_port_set_, "in_dispatch_queue_credits", sparta::SchedulingPhase::Tick, 0};
-        sparta::DataInPort<InstPtr> in_rename_retire_ack_{&unit_port_set_, "in_rename_retire_ack",
-                                                          1};
+        sparta::DataInPort<InstGroupPtr> in_rename_retire_ack_{&unit_port_set_,
+            "in_rename_retire_ack", 1};
 
         // For flush
         sparta::DataInPort<FlushManager::FlushingCriteria> in_reorder_flush_{
             &unit_port_set_, "in_reorder_flush", sparta::SchedulingPhase::Flush, 1};
 
         sparta::UniqueEvent<> ev_rename_insts_{&unit_event_set_, "rename_insts",
-                                               CREATE_SPARTA_HANDLER(Rename, renameInstructions_)};
+            CREATE_SPARTA_HANDLER(Rename, renameInstructions_)};
+
+        sparta::UniqueEvent<> ev_debug_rename_{
+            &unit_event_set_, "debug_rename",
+            CREATE_SPARTA_HANDLER(Rename, dumpDebugContentHearbeat_)};
+
         sparta::UniqueEvent<> ev_schedule_rename_{&unit_event_set_, "schedule_rename",
-                                                  CREATE_SPARTA_HANDLER(Rename, scheduleRenaming_)};
+            CREATE_SPARTA_HANDLER(Rename, scheduleRenaming_)};
 
-        const uint32_t num_to_rename_per_cycle_;
-        uint32_t num_to_rename_ = 0;
-        uint32_t credits_dispatch_ = 0;
+        sparta::Event<> ev_sanity_check_{&unit_event_set_, "ev_sanity_check",
+            CREATE_SPARTA_HANDLER(Rename, sanityCheck_)};
 
-        // Scoreboards
-        using Scoreboards = std::array<sparta::Scoreboard*, core_types::N_REGFILES>;
-        Scoreboards scoreboards_;
         // histogram counter for number of renames each time scheduleRenaming_ is called
         sparta::BasicHistogram<int> rename_histogram_;
-        // map of ARF -> PRF
-        uint32_t map_table_[core_types::N_REGFILES][32];
 
         // reference counter for PRF
-        std::array<std::vector<int32_t>, core_types::N_REGFILES> reference_counter_;
-        // list of free PRF that are available to map
-        std::queue<uint32_t> freelist_[core_types::N_REGFILES];
-
-        // used to track current number of each type of RF instruction at each
-        // given index in the uop_queue_
-        struct RegCountData
+        struct Producer
         {
-            uint32_t cumulative_reg_counts[core_types::RegFile::N_REGFILES] = {0};
+            Producer(uint32_t _cnt) : cnt(_cnt) {}
+
+            uint32_t cnt = 0;
+            uint64_t producer_id = 0;
+            InstWeakPtr producer;
+            bool producer_is_load = false;
         };
 
-        std::deque<RegCountData> uop_queue_regcount_data_;
+        struct RegfileComponents
+        {
+            // Scoreboard
+            sparta::Scoreboard* scoreboard = nullptr;
 
-        // Used to track inflight instructions for the purpose of recovering
-        // the rename data structures
-        std::deque<InstPtr> inst_queue_;
+            // reference counter for PRF
+            std::vector<Producer> reference_counter;
+
+            // list of free PRF that are available to map
+            std::queue<uint32_t> freelist;
+        };
+
+        using RegfileComponentArray = std::vector<RegfileComponents>;
+        RegfileComponentArray regfile_components_{core_types::RegFile::N_REGFILES};
+
+        void updateRegcountData_();
+
+        // RENAME (Decode Mapping) event
+        sparta::pevents::PeventCollector<InstPEventPairs> rename_event_;
+
+        // Counters
+        sparta::Counter move_eliminations_{getStatisticSet(), "move_eliminations",
+            "Number of times Rename eliminated a move instruction",
+            sparta::Counter::COUNT_NORMAL};
 
         ///////////////////////////////////////////////////////////////////////
         // Stall counters
         enum StallReason
-        {
-            NO_DECODE_INSTS,     // No insts from Decode
-            NO_DISPATCH_CREDITS, // No credits from Dispatch
-            NO_RENAMES,          // Out of renames
-            NOT_STALLED,         // Made forward progress (dipatched
-                                 // all instructions or no
-                                 // instructions)
-            N_STALL_REASONS
-        };
+            {
+                NO_DECODE_INSTS,     // No insts from Decode
+                NO_DISPATCH_CREDITS, // No credits from Dispatch
+                NO_INTEGER_RENAMES,  // Out of integer renames
+                NO_FLOAT_RENAMES,    // Out of float renames
+                NO_VECTOR_RENAMES,   // Out of vector renames
+                NOT_STALLED,         // Made forward progress (dipatched
+                // all instructions or no
+                // instructions)
+                N_STALL_REASONS
+            };
 
-        StallReason current_stall_ = NO_DECODE_INSTS;
         friend std::ostream & operator<<(std::ostream &, const StallReason &);
 
         // Counters -- this is only supported in C++11 -- uses
@@ -133,11 +170,46 @@ namespace olympia
                                   sparta::Counter::COUNT_NORMAL, getClock()),
              sparta::CycleCounter(getStatisticSet(), "stall_no_dispatch_credits",
                                   "No Dispatch Credits", sparta::Counter::COUNT_NORMAL, getClock()),
-             sparta::CycleCounter(getStatisticSet(), "stall_no_renames", "No Renames",
+             sparta::CycleCounter(getStatisticSet(), "stall_no_integer_renames",
+                                  "No Integer Renames", sparta::Counter::COUNT_NORMAL, getClock()),
+             sparta::CycleCounter(getStatisticSet(), "stall_no_float_renames", "No Float Renames",
+                                  sparta::Counter::COUNT_NORMAL, getClock()),
+             sparta::CycleCounter(getStatisticSet(), "stall_no_vector_renames", "No Vector Renames",
                                   sparta::Counter::COUNT_NORMAL, getClock()),
              sparta::CycleCounter(getStatisticSet(), "stall_not_stalled",
                                   "Rename not stalled, all instructions renamed",
                                   sparta::Counter::COUNT_NORMAL, getClock())}};
+
+        // used to track current number of each type of RF instruction at each
+        // given index in the uop_queue
+        struct RegCountData
+        {
+            uint32_t cumulative_reg_counts[core_types::RegFile::N_REGFILES] = {0};
+        };
+
+        // This is ordered roughly from most-accessed ->
+        // least-accessed, and members that are frequently accessed
+        // together are next to each other
+        uint32_t credits_dispatch_ = 0;
+        InstBuffer uop_queue_;
+        RegCountData uop_queue_regcount_data_;
+
+        // map of ARF -> PRF
+        std::array<std::array<uint32_t, NUM_RISCV_REGS_>, core_types::N_REGFILES> map_table_;
+
+        // Used to track inflight instructions for the purpose of recovering
+        // the rename data structures
+        std::deque<InstPtr> inst_queue_;
+        StallReason current_stall_ = StallReason::NO_DECODE_INSTS;
+
+        void setStall_(const StallReason reason)
+        {
+            stall_counters_[current_stall_].stopCounting();
+            current_stall_ = reason;
+            stall_counters_[current_stall_].startCounting();
+        }
+
+        StallReason getStall_() const { return current_stall_; }
 
         //! Rename setup
         void setupRename_();
@@ -148,40 +220,63 @@ namespace olympia
         //! Process new instructions coming in from decode
         void decodedInstructions_(const InstGroupPtr &);
 
+        //! Can the oldest instruction secure a rename?
+        std::pair<bool, Rename::StallReason> enoughRenames_() const;
+
         //! Schedule renaming if there are enough PRFs in the freelist_
         void scheduleRenaming_();
 
         //! Rename instructions
         void renameInstructions_();
 
+        //! Rename the sources
+        void renameSources_(const InstPtr &);
+
+        //! Rename the dests
+        void renameDests_(const InstPtr &);
+
         //! Flush instructions.
         void handleFlush_(const FlushManager::FlushingCriteria & criteria);
 
         // Get Retired Instructions
-        void getAckFromROB_(const InstPtr &);
+        void getAckFromROB_(const InstGroupPtr &);
 
         // Friend class used in rename testing
         friend class RenameTester;
+
+        // Sanity checker
+        void sanityCheck_();
+
+        // Dump debug content on failure
+        void dumpDebugContentHearbeat_();
+        template <class OStreamT> void dumpRenameContent_(OStreamT & output) const;
+        void dumpDebugContent_(std::ostream & output) const override final;
     };
 
     inline std::ostream & operator<<(std::ostream & os, const Rename::StallReason & stall)
     {
         switch (stall)
         {
-        case Rename::StallReason::NO_DECODE_INSTS:
-            os << "NO_DECODE_INSTS";
-            break;
-        case Rename::StallReason::NO_DISPATCH_CREDITS:
-            os << "NO_DISPATCH_CREDITS";
-            break;
-        case Rename::StallReason::NO_RENAMES:
-            os << "NO_RENAMES";
-            break;
-        case Rename::StallReason::NOT_STALLED:
-            os << "NOT_STALLED";
-            break;
-        case Rename::StallReason::N_STALL_REASONS:
-            sparta_assert(false, "How'd we get here?");
+            case Rename::StallReason::NO_DECODE_INSTS:
+                os << "NO_DECODE_INSTS";
+                break;
+            case Rename::StallReason::NO_DISPATCH_CREDITS:
+                os << "NO_DISPATCH_CREDITS";
+                break;
+            case Rename::StallReason::NO_INTEGER_RENAMES:
+                os << "NO_INTEGER_RENAMES";
+                break;
+            case Rename::StallReason::NO_FLOAT_RENAMES:
+                os << "NO_FLOAT_RENAMES";
+                break;
+            case Rename::StallReason::NO_VECTOR_RENAMES:
+                os << "NO_VECTOR_RENAMES";
+                break;
+            case Rename::StallReason::NOT_STALLED:
+                os << "NOT_STALLED";
+                break;
+            case Rename::StallReason::N_STALL_REASONS:
+                sparta_assert(false, "How'd we get here?");
         }
         return os;
     }
@@ -189,10 +284,10 @@ namespace olympia
     //! Rename's factory class. Don't create Rename without it
     class RenameFactory : public sparta::ResourceFactory<Rename, Rename::RenameParameterSet>
     {
-      public:
+    public:
         void onConfiguring(sparta::ResourceTreeNode* node) override;
 
-      private:
+    private:
         using ScoreboardTreeNodes = std::vector<std::unique_ptr<sparta::TreeNode>>;
         using ScoreboardFactories = std::array<
             sparta::ResourceFactory<sparta::Scoreboard, sparta::Scoreboard::ScoreboardParameters>,
@@ -200,5 +295,6 @@ namespace olympia
         ScoreboardFactories sb_facts_;
         ScoreboardTreeNodes sb_tns_;
     };
+
     class RenameTester;
 } // namespace olympia

--- a/docs/rename.md
+++ b/docs/rename.md
@@ -1,0 +1,150 @@
+:doctitle: Olympia Rename Design
+
+:toc:
+
+[[Document_Information]]
+== Document Information
+
+<meta data>
+
+[[Revision_History]]
+=== Revision History
+
+<newest revision at the top of this table>
+
+[width="100%",cols="11%,11%,16%,62%",options="header",]
+| ===        |            |                |                      |
+| *Revision* | *Date*     | *Author*       | *Summary of Changes* |
+| 0.1        | 2025.03.19 | Knute Lingaard | Initial revision     |
+| ===        |            |                |                      |
+
+[[Conventions_and_Terminology]]
+=== Conventions and Terminology
+
+<terms or acronyms used in the document that may not have general visibility>
+
+[width="100%",cols="17%,83%",options="header",]
+|===
+|Label |Description
+|<label> |<description
+| |
+|===
+
+[[Related_Documents]]
+=== Related Documents
+
+* Register Renaming https://en.wikipedia.org/wiki/Register_renaming
+
+[[Notes_Open_Issues]]
+=== Notes/Open Issues
+
+<advisories, limitations, unsolved problems>
+
+* No open issues
+
+[[OVERVIEW]]
+== OVERVIEW
+
+<Overview of the unit, what does it do, where does it fit into Olympia
+proper, use the section below to discuss the context>
+
+The Rename block of Olympia enables a simple OoO architectural to
+physical mapping design for CPU micro-architectural analysis.  The
+principles are simple: rename architectural
+
+
+[[Overview_Block_Diagram]]
+=== Overview Block Diagram
+
+<Add an overview block diagram>
+
+[[Functional_Description]]
+== Functional Description
+
+<this begins the detailed description of the unit. Typically, this
+discusses each major block in a separate sub-section>
+
+[[Unit_Block_Diagram]]
+=== Unit Block Diagram
+
+<Add an overview block diagram>
+
+
+[[Block_Diagram_Description]]
+=== Block Diagram Description
+
+<walk through the block diagram>
+
+[[Description_of_Block_B1]]
+== Description of Block <B1>
+
+<this section contains block level details>
+
+[[Operation]]
+=== Operation
+
+<describe the low-level operation of the block>
+
+[[Interfaces]]
+=== Interfaces
+
+<this is typically a general list of block interfaces, this changes with
+development, final design will finalize this section>
+
+[width="100%",cols="18%,21%,61%",options="header",]
+|===
+|*Name* |*C++ Type* |*Purpose/Description*
+| | |
+| | |
+| | |
+|===
+
+[[CPP_Class_Description]]
+=== C++ Class Description
+
+<describe the class, it’s inheritance assumptions and data structures
+used by the class
+
+[[Parameterization]]
+=== Parameterization
+
+<top level parameterization, include hidden and those visible in arch
+yaml>
+
+[[Test_Bench_Description]]
+== Test Bench Description
+
+<description of what is covered by the test bench, description of each
+test as appropriate
+
+[[Description_of_Test_1]]
+=== Description of Test 1
+
+<discuss test 1>
+
+[[Description_of_Test_2]]
+=== Description of Test 2
+
+<discuss test 2>
+
+[[Future_Work_or_Features]]
+== Future Work or Features
+
+<forward looking statements>
+
+[[References_Citations]]
+== References/Citations
+
+<Add references as needed>
+
+[1] <insert citation>
+
+[[Appendices]]
+== Appendices
+
+<as needed>
+
+[[Appendix_1]]
+=== Appendix 1
+
+<as needed>

--- a/test/core/dispatch/expected_output/big_core.out.EXPECTED
+++ b/test/core/dispatch/expected_output/big_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:01:55 2024
-#Elapsed:  0.001359s
+#Start:    Thursday Thu Mar 20 11:49:32 2025
+#Elapsed:  0.00165s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: DIViq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq1
@@ -32,40 +32,41 @@
 {0000000000 00000000 top.execute.exe8 info} ExecutePipe: ExecutePipe construct: #8
 {0000000000 00000000 top.execute.exe9 info} ExecutePipe: ExecutePipe construct: #9
 {0000000000 00000000 top.execute.exe10 info} ExecutePipe: ExecutePipe construct: #10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq4 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq5 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add, 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add, 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0,3] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [5,32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [7,33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 2 -> 32 from 2
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 32
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 4 -> 33
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 6 -> 34 from 6
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 6 -> 34
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 8 -> 35 from 8
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 4
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add, 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
@@ -77,27 +78,28 @@
 {0000000002 00000002 top.dispatch info} acceptInst: iq2: dispatching uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  to iq2 of target type: INT
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:4    RENAMED 0 pid:0 uopid:0 'add	10,8,9' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [9,34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:5    RENAMED 0 pid:0 uopid:0 'add	12,10,11' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [11,35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:6    RENAMED 0 pid:0 uopid:0 'add	14,12,13' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [13,36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:7    RENAMED 0 pid:0 uopid:0 'add	16,14,15' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [15,37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:4 BEFORE_FETCH 0 pid:0 uopid:0 'add	10,8,9' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 8 -> 35
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 9 -> 9
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 10 -> 36 from 10
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:5 BEFORE_FETCH 0 pid:0 uopid:0 'add	12,10,11' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 10 -> 36
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 12 -> 37 from 12
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:6 BEFORE_FETCH 0 pid:0 uopid:0 'add	14,12,13' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 12 -> 37
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 13 -> 13
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 14 -> 38 from 14
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:7 BEFORE_FETCH 0 pid:0 uopid:0 'add	16,14,15' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 14 -> 38
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 15 -> 15
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 16 -> 39 from 16
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 4
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add, 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000003 00000003 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[0,3] rf: integer
-{0000000003 00000003 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,32] rf: integer
+{0000000003 00000003 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[3,32] rf: integer
+{0000000003 00000003 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,33] rf: integer
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add
 {0000000003 00000003 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1'  to exe_pipe exe0
 {0000000003 00000003 top.execute.exe0 info} insertInst: Executing: uid:0  SCHEDULED 0 pid:0 uopid:0 'add	2,0,1'  for 4
@@ -110,27 +112,28 @@
 {0000000003 00000003 top.dispatch info} acceptInst: iq2: dispatching uid:5    RENAMED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to iq2 of target type: INT
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [17,38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [19,39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:10    RENAMED 0 pid:0 uopid:0 'add	22,20,21' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [21,40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:11    RENAMED 0 pid:0 uopid:0 'add	24,22,23' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [23,41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [42] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:8 BEFORE_FETCH 0 pid:0 uopid:0 'add	18,16,17' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 16 -> 39
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 17 -> 17
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 18 -> 40 from 18
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:9 BEFORE_FETCH 0 pid:0 uopid:0 'add	20,18,19' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 18 -> 40
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 19 -> 19
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 20 -> 41 from 20
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:10 BEFORE_FETCH 0 pid:0 uopid:0 'add	22,20,21' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 20 -> 41
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 21 -> 21
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 22 -> 42 from 22
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:11 BEFORE_FETCH 0 pid:0 uopid:0 'add	24,22,23' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 22 -> 42
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 23 -> 23
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 24 -> 43 from 24
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 4
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add, 0x00000000 UID(20)  PID(0)  add, 0x00000000 UID(21)  PID(0)  add
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,33] rf: integer
-{0000000004 00000004 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,34] rf: integer
-{0000000004 00000004 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,35] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,34] rf: integer
+{0000000004 00000004 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,35] rf: integer
+{0000000004 00000004 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,36] rf: integer
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Num to dispatch: 3
@@ -141,27 +144,28 @@
 {0000000004 00000004 top.dispatch info} acceptInst: iq2: dispatching uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  to iq2 of target type: INT
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:12    RENAMED 0 pid:0 uopid:0 'add	26,24,25' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [25,42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:13    RENAMED 0 pid:0 uopid:0 'add	28,26,27' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [27,43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:14    RENAMED 0 pid:0 uopid:0 'add	30,28,29' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [29,44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [45] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:15    RENAMED 0 pid:0 uopid:0 'add	0,30,31' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [45] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [31,45] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:12 BEFORE_FETCH 0 pid:0 uopid:0 'add	26,24,25' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 24 -> 43
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 25 -> 25
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 26 -> 44 from 26
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:13 BEFORE_FETCH 0 pid:0 uopid:0 'add	28,26,27' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 26 -> 44
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 27 -> 27
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 28 -> 45 from 28
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:14 BEFORE_FETCH 0 pid:0 uopid:0 'add	30,28,29' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 28 -> 45
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 29 -> 29
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 30 -> 46 from 30
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:15 BEFORE_FETCH 0 pid:0 uopid:0 'add	0,30,31' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 30 -> 46
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 31 -> 31
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add, 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 4
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(22)  PID(0)  add, 0x00000000 UID(23)  PID(0)  add, 0x00000000 UID(24)  PID(0)  add, 0x00000000 UID(25)  PID(0)  add
 {0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,36] rf: integer
-{0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,37] rf: integer
-{0000000005 00000005 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,38] rf: integer
+{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,37] rf: integer
+{0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,38] rf: integer
+{0000000005 00000005 top.execute.iq2 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,39] rf: integer
 {0000000005 00000005 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add, 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add
 {0000000005 00000005 top.execute.exe0 info} completeInst_: Completing inst: uid:0  COMPLETED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000005 00000005 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  to exe_pipe exe2
@@ -171,81 +175,83 @@
 {0000000005 00000005 top.dispatch info} acceptInst: iq0: dispatching uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to iq0 of target type: INT
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:16    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:17    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [3,46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [47] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:18    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [47] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [5,47] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [48] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:19    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [48] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [7,48] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [49] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:16 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 2 -> 47 from 32
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:17 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 2 -> 47
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 4 -> 48 from 33
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:18 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 4 -> 48
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 6 -> 49 from 34
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:19 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 6 -> 49
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 8 -> 50 from 35
+{0000000005 00000005 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add, 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 4
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(26)  PID(0)  add, 0x00000000 UID(27)  PID(0)  add, 0x00000000 UID(28)  PID(0)  add, 0x00000000 UID(29)  PID(0)  add
-{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,39] rf: integer
+{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,40] rf: integer
 {0000000006 00000006 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add, 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add
-{0000000006 00000006 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000006 00000006 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000006 00000006 top.execute.exe2 info} executeInst_: Executed inst: uid:1  SCHEDULED 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NO_DISPATCH_CREDITS
 {0000000007 00000007 top.execute.iq2 info} handleOperandIssueCheck_: Sending to issue queue uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000007 00000007 top.execute.exe2 info} completeInst_: Completing inst: uid:1  COMPLETED 0 pid:0 uopid:0 'add	4,2,3' 
 {0000000007 00000007 top.execute.iq2 info} sendReadyInsts_: Sending instruction uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  to exe_pipe exe4
 {0000000007 00000007 top.execute.exe4 info} insertInst: Executing: uid:2  SCHEDULED 0 pid:0 uopid:0 'add	6,4,5'  for 8
 {0000000007 00000007 top.dispatch info} receiveCredits_: iq2 got 1 credits, total: 6
-{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000008 00000008 top.execute.exe4 info} executeInst_: Executed inst: uid:2  SCHEDULED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000009 00000009 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000009 00000009 top.execute.exe4 info} completeInst_: Completing inst: uid:2  COMPLETED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000009 00000009 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  to exe_pipe exe0
 {0000000009 00000009 top.execute.exe0 info} insertInst: Executing: uid:3  SCHEDULED 0 pid:0 uopid:0 'add	8,6,7'  for 10
 {0000000009 00000009 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 6
-{0000000009 00000009 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000009 00000009 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000010 00000010 top.execute.exe0 info} executeInst_: Executed inst: uid:3  SCHEDULED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000011 00000011 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000011 00000011 top.execute.exe0 info} completeInst_: Completing inst: uid:3  COMPLETED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000011 00000011 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  to exe_pipe exe2
 {0000000011 00000011 top.execute.exe2 info} insertInst: Executing: uid:4  SCHEDULED 0 pid:0 uopid:0 'add	10,8,9'  for 12
 {0000000011 00000011 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 7
-{0000000011 00000011 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000011 00000011 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000012 00000012 top.execute.exe2 info} executeInst_: Executed inst: uid:4  SCHEDULED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000013 00000013 top.execute.iq2 info} handleOperandIssueCheck_: Sending to issue queue uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000013 00000013 top.execute.exe2 info} completeInst_: Completing inst: uid:4  COMPLETED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000013 00000013 top.execute.iq2 info} sendReadyInsts_: Sending instruction uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to exe_pipe exe4
 {0000000013 00000013 top.execute.exe4 info} insertInst: Executing: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11'  for 14
 {0000000013 00000013 top.dispatch info} receiveCredits_: iq2 got 1 credits, total: 7
-{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000014 00000014 top.execute.exe4 info} executeInst_: Executed inst: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000015 00000015 top.execute.exe4 info} completeInst_: Completing inst: uid:5  COMPLETED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  to exe_pipe exe0
 {0000000015 00000015 top.execute.exe0 info} insertInst: Executing: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13'  for 16
 {0000000015 00000015 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 7
-{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000016 00000016 top.execute.exe0 info} executeInst_: Executed inst: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000017 00000017 top.execute.exe0 info} completeInst_: Completing inst: uid:6  COMPLETED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  to exe_pipe exe2
 {0000000017 00000017 top.execute.exe2 info} insertInst: Executing: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15'  for 18
 {0000000017 00000017 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 8
-{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000018 00000018 top.execute.exe2 info} executeInst_: Executed inst: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq2 info} handleOperandIssueCheck_: Sending to issue queue uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000019 00000019 top.execute.exe2 info} completeInst_: Completing inst: uid:7  COMPLETED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq2 info} sendReadyInsts_: Sending instruction uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  to exe_pipe exe4
 {0000000019 00000019 top.execute.exe4 info} insertInst: Executing: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17'  for 20
 {0000000019 00000019 top.dispatch info} receiveCredits_: iq2 got 1 credits, total: 8
-{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000020 00000020 top.execute.exe4 info} executeInst_: Executed inst: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000021 00000021 top.execute.exe4 info} completeInst_: Completing inst: uid:8  COMPLETED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to exe_pipe exe0
 {0000000021 00000021 top.execute.exe0 info} insertInst: Executing: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19'  for 22
 {0000000021 00000021 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 8
-{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000022 00000022 top.execute.exe0 info} executeInst_: Executed inst: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000023 00000023 top.execute.exe0 info} completeInst_: Completing inst: uid:9  COMPLETED 0 pid:0 uopid:0 'add	20,18,19' 

--- a/test/core/dispatch/expected_output/medium_core.out.EXPECTED
+++ b/test/core/dispatch/expected_output/medium_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:01:55 2024
-#Elapsed:  0.001281s
+#Start:    Thursday Thu Mar 20 11:49:32 2025
+#Elapsed:  0.001557s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -27,38 +27,39 @@
 {0000000000 00000000 top.execute.exe4 info} ExecutePipe: ExecutePipe construct: #4
 {0000000000 00000000 top.execute.exe5 info} ExecutePipe: ExecutePipe construct: #5
 {0000000000 00000000 top.execute.exe6 info} ExecutePipe: ExecutePipe construct: #6
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq4 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add, 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add, 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0,3] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [5,32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [7,33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 2 -> 32 from 2
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 32
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 4 -> 33
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 6 -> 34 from 6
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 6 -> 34
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 8 -> 35 from 8
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 4
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add, 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
@@ -69,26 +70,27 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  to iq1 of target type: INT
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5'  stall: INT_BUSY
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:4    RENAMED 0 pid:0 uopid:0 'add	10,8,9' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [9,34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:5    RENAMED 0 pid:0 uopid:0 'add	12,10,11' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [11,35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:6    RENAMED 0 pid:0 uopid:0 'add	14,12,13' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [13,36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:7    RENAMED 0 pid:0 uopid:0 'add	16,14,15' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [15,37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:4 BEFORE_FETCH 0 pid:0 uopid:0 'add	10,8,9' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 8 -> 35
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 9 -> 9
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 10 -> 36 from 10
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:5 BEFORE_FETCH 0 pid:0 uopid:0 'add	12,10,11' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 10 -> 36
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 12 -> 37 from 12
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:6 BEFORE_FETCH 0 pid:0 uopid:0 'add	14,12,13' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 12 -> 37
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 13 -> 13
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 14 -> 38 from 14
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:7 BEFORE_FETCH 0 pid:0 uopid:0 'add	16,14,15' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 14 -> 38
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 15 -> 15
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 16 -> 39 from 16
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 4
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add, 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000003 00000003 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[0,3] rf: integer
+{0000000003 00000003 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[3,32] rf: integer
 {0000000003 00000003 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add
 {0000000003 00000003 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1'  to exe_pipe exe0
 {0000000003 00000003 top.execute.exe0 info} insertInst: Executing: uid:0  SCHEDULED 0 pid:0 uopid:0 'add	2,0,1'  for 4
@@ -100,26 +102,27 @@
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  to iq1 of target type: INT
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:4    RENAMED 0 pid:0 uopid:0 'add	10,8,9'  stall: INT_BUSY
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [17,38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [19,39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:10    RENAMED 0 pid:0 uopid:0 'add	22,20,21' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [21,40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:11    RENAMED 0 pid:0 uopid:0 'add	24,22,23' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [23,41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [42] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:8 BEFORE_FETCH 0 pid:0 uopid:0 'add	18,16,17' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 16 -> 39
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 17 -> 17
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 18 -> 40 from 18
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:9 BEFORE_FETCH 0 pid:0 uopid:0 'add	20,18,19' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 18 -> 40
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 19 -> 19
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 20 -> 41 from 20
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:10 BEFORE_FETCH 0 pid:0 uopid:0 'add	22,20,21' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 20 -> 41
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 21 -> 21
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 22 -> 42 from 22
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:11 BEFORE_FETCH 0 pid:0 uopid:0 'add	24,22,23' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 22 -> 42
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 23 -> 23
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 24 -> 43 from 24
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 4
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add, 0x00000000 UID(20)  PID(0)  add, 0x00000000 UID(21)  PID(0)  add
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,32] rf: integer
-{0000000004 00000004 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,33] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,33] rf: integer
+{0000000004 00000004 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,34] rf: integer
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Num to dispatch: 3
@@ -129,26 +132,27 @@
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to iq1 of target type: INT
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:6    RENAMED 0 pid:0 uopid:0 'add	14,12,13'  stall: INT_BUSY
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:12    RENAMED 0 pid:0 uopid:0 'add	26,24,25' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [25,42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:13    RENAMED 0 pid:0 uopid:0 'add	28,26,27' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [27,43] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:14    RENAMED 0 pid:0 uopid:0 'add	30,28,29' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [29,44] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [45] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:15    RENAMED 0 pid:0 uopid:0 'add	0,30,31' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [45] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [31,45] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:12 BEFORE_FETCH 0 pid:0 uopid:0 'add	26,24,25' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 24 -> 43
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 25 -> 25
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 26 -> 44 from 26
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:13 BEFORE_FETCH 0 pid:0 uopid:0 'add	28,26,27' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 26 -> 44
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 27 -> 27
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 28 -> 45 from 28
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:14 BEFORE_FETCH 0 pid:0 uopid:0 'add	30,28,29' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 28 -> 45
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 29 -> 29
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 30 -> 46 from 30
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:15 BEFORE_FETCH 0 pid:0 uopid:0 'add	0,30,31' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 30 -> 46
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 31 -> 31
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add, 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 4
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(22)  PID(0)  add, 0x00000000 UID(23)  PID(0)  add, 0x00000000 UID(24)  PID(0)  add, 0x00000000 UID(25)  PID(0)  add
 {0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,34] rf: integer
-{0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,35] rf: integer
+{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,35] rf: integer
+{0000000005 00000005 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,36] rf: integer
 {0000000005 00000005 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add, 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add
 {0000000005 00000005 top.execute.exe0 info} completeInst_: Completing inst: uid:0  COMPLETED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000005 00000005 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  to exe_pipe exe1
@@ -161,17 +165,18 @@
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  to iq1 of target type: INT
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17'  stall: INT_BUSY
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:16    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:17    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [3,46] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [47] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:16 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 2 -> 47 from 32
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:17 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 2 -> 47
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 4 -> 48 from 33
+{0000000005 00000005 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 2
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(26)  PID(0)  add, 0x00000000 UID(27)  PID(0)  add
-{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,36] rf: integer
-{0000000006 00000006 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,37] rf: integer
+{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,37] rf: integer
+{0000000006 00000006 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,38] rf: integer
 {0000000006 00000006 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add
 {0000000006 00000006 top.execute.exe1 info} executeInst_: Executed inst: uid:1  SCHEDULED 0 pid:0 uopid:0 'add	4,2,3' 
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Num to dispatch: 2
@@ -180,74 +185,76 @@
 {0000000006 00000006 top.dispatch info} acceptInst: iq1: dispatching uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to iq1 of target type: INT
 {0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid:18    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [47] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [5,47] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [48] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid:19    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [48] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [7,48] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [49] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: Renaming uid:18 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 4 -> 48
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000006 00000006 top.rename info} renameDests_: 	dest rename integer 6 -> 49 from 34
+{0000000006 00000006 top.rename info} renameInstructions_: Renaming uid:19 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 6 -> 49
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000006 00000006 top.rename info} renameDests_: 	dest rename integer 8 -> 50 from 35
+{0000000006 00000006 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add
 {0000000006 00000006 top.decode info} inCredits: Got credits from dut: 2
 {0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(28)  PID(0)  add, 0x00000000 UID(29)  PID(0)  add
 {0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,38] rf: integer
-{0000000007 00000007 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,39] rf: integer
+{0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,39] rf: integer
+{0000000007 00000007 top.execute.iq1 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,40] rf: integer
 {0000000007 00000007 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add
-{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000007 00000007 top.execute.exe1 info} completeInst_: Completing inst: uid:1  COMPLETED 0 pid:0 uopid:0 'add	4,2,3' 
 {0000000007 00000007 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  to exe_pipe exe0
 {0000000007 00000007 top.execute.exe0 info} insertInst: Executing: uid:2  SCHEDULED 0 pid:0 uopid:0 'add	6,4,5'  for 8
 {0000000007 00000007 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 5
-{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000007 00000007 top.dispatch info} scheduleDispatchSession: no rob credits
+{0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NO_DISPATCH_CREDITS
 {0000000008 00000008 top.execute.exe0 info} executeInst_: Executed inst: uid:2  SCHEDULED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000009 00000009 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000009 00000009 top.execute.exe0 info} completeInst_: Completing inst: uid:2  COMPLETED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000009 00000009 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  to exe_pipe exe1
 {0000000009 00000009 top.execute.exe1 info} insertInst: Executing: uid:3  SCHEDULED 0 pid:0 uopid:0 'add	8,6,7'  for 10
 {0000000009 00000009 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 5
-{0000000009 00000009 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000009 00000009 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000010 00000010 top.execute.exe1 info} executeInst_: Executed inst: uid:3  SCHEDULED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000011 00000011 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000011 00000011 top.execute.exe1 info} completeInst_: Completing inst: uid:3  COMPLETED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000011 00000011 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  to exe_pipe exe0
 {0000000011 00000011 top.execute.exe0 info} insertInst: Executing: uid:4  SCHEDULED 0 pid:0 uopid:0 'add	10,8,9'  for 12
 {0000000011 00000011 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 6
-{0000000011 00000011 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000011 00000011 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000012 00000012 top.execute.exe0 info} executeInst_: Executed inst: uid:4  SCHEDULED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000013 00000013 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000013 00000013 top.execute.exe0 info} completeInst_: Completing inst: uid:4  COMPLETED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000013 00000013 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to exe_pipe exe1
 {0000000013 00000013 top.execute.exe1 info} insertInst: Executing: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11'  for 14
 {0000000013 00000013 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 6
-{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000014 00000014 top.execute.exe1 info} executeInst_: Executed inst: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000015 00000015 top.execute.exe1 info} completeInst_: Completing inst: uid:5  COMPLETED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  to exe_pipe exe0
 {0000000015 00000015 top.execute.exe0 info} insertInst: Executing: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13'  for 16
 {0000000015 00000015 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 7
-{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000016 00000016 top.execute.exe0 info} executeInst_: Executed inst: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000017 00000017 top.execute.exe0 info} completeInst_: Completing inst: uid:6  COMPLETED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  to exe_pipe exe1
 {0000000017 00000017 top.execute.exe1 info} insertInst: Executing: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15'  for 18
 {0000000017 00000017 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 7
-{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000018 00000018 top.execute.exe1 info} executeInst_: Executed inst: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000019 00000019 top.execute.exe1 info} completeInst_: Completing inst: uid:7  COMPLETED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  to exe_pipe exe0
 {0000000019 00000019 top.execute.exe0 info} insertInst: Executing: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17'  for 20
 {0000000019 00000019 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 8
-{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000020 00000020 top.execute.exe0 info} executeInst_: Executed inst: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq1 info} handleOperandIssueCheck_: Sending to issue queue uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000021 00000021 top.execute.exe0 info} completeInst_: Completing inst: uid:8  COMPLETED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq1 info} sendReadyInsts_: Sending instruction uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to exe_pipe exe1
 {0000000021 00000021 top.execute.exe1 info} insertInst: Executing: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19'  for 22
 {0000000021 00000021 top.dispatch info} receiveCredits_: iq1 got 1 credits, total: 8
-{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000022 00000022 top.execute.exe1 info} executeInst_: Executed inst: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000023 00000023 top.execute.exe1 info} completeInst_: Completing inst: uid:9  COMPLETED 0 pid:0 uopid:0 'add	20,18,19' 

--- a/test/core/dispatch/expected_output/small_core.out.EXPECTED
+++ b/test/core/dispatch/expected_output/small_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:01:55 2024
-#Elapsed:  0.001895s
+#Start:    Thursday Thu Mar 20 11:49:32 2025
+#Elapsed:  0.001524s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -23,36 +23,37 @@
 {0000000000 00000000 top.execute.exe1 info} ExecutePipe: ExecutePipe construct: #1
 {0000000000 00000000 top.execute.exe2 info} ExecutePipe: ExecutePipe construct: #2
 {0000000000 00000000 top.execute.exe3 info} ExecutePipe: ExecutePipe construct: #3
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 10 credits, total: 10
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add, 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add, 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [0,3] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [5,32] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [7,33] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 2 -> 32 from 2
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 32
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 4 -> 33
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 6 -> 34 from 6
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 6 -> 34
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 8 -> 35 from 8
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 4
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add, 0x00000000 UID(12)  PID(0)  add, 0x00000000 UID(13)  PID(0)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(0)  add, 0x00000000 UID(1)  PID(0)  add, 0x00000000 UID(2)  PID(0)  add, 0x00000000 UID(3)  PID(0)  add
@@ -61,22 +62,23 @@
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1'  to iq0 of target type: INT
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:1    RENAMED 0 pid:0 uopid:0 'add	4,2,3'  stall: INT_BUSY
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:4    RENAMED 0 pid:0 uopid:0 'add	10,8,9' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [9,34] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:5    RENAMED 0 pid:0 uopid:0 'add	12,10,11' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [11,35] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:6    RENAMED 0 pid:0 uopid:0 'add	14,12,13' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [13,36] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:7    RENAMED 0 pid:0 uopid:0 'add	16,14,15' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [15,37] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [38] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:4 BEFORE_FETCH 0 pid:0 uopid:0 'add	10,8,9' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 8 -> 35
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 9 -> 9
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 10 -> 36 from 10
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:5 BEFORE_FETCH 0 pid:0 uopid:0 'add	12,10,11' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 10 -> 36
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 12 -> 37 from 12
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:6 BEFORE_FETCH 0 pid:0 uopid:0 'add	14,12,13' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 12 -> 37
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 13 -> 13
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 14 -> 38 from 14
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:7 BEFORE_FETCH 0 pid:0 uopid:0 'add	16,14,15' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 14 -> 38
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 15 -> 15
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 16 -> 39 from 16
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(4)  PID(0)  add, 0x00000000 UID(5)  PID(0)  add, 0x00000000 UID(6)  PID(0)  add, 0x00000000 UID(7)  PID(0)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 4
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(14)  PID(0)  add, 0x00000000 UID(15)  PID(0)  add, 0x00000000 UID(16)  PID(0)  add, 0x00000000 UID(17)  PID(0)  add
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:0 uopid:0 'add	2,0,1' 
@@ -89,25 +91,26 @@
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  to iq0 of target type: INT
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:2    RENAMED 0 pid:0 uopid:0 'add	6,4,5'  stall: INT_BUSY
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [17,38] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [19,39] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:10    RENAMED 0 pid:0 uopid:0 'add	22,20,21' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [21,40] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:11    RENAMED 0 pid:0 uopid:0 'add	24,22,23' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [23,41] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [42] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:8 BEFORE_FETCH 0 pid:0 uopid:0 'add	18,16,17' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 16 -> 39
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 17 -> 17
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 18 -> 40 from 18
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:9 BEFORE_FETCH 0 pid:0 uopid:0 'add	20,18,19' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 18 -> 40
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 19 -> 19
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 20 -> 41 from 20
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:10 BEFORE_FETCH 0 pid:0 uopid:0 'add	22,20,21' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 20 -> 41
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 21 -> 21
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 22 -> 42 from 22
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:11 BEFORE_FETCH 0 pid:0 uopid:0 'add	24,22,23' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 22 -> 42
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 23 -> 23
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 24 -> 43 from 24
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 4
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(18)  PID(0)  add, 0x00000000 UID(19)  PID(0)  add, 0x00000000 UID(20)  PID(0)  add, 0x00000000 UID(21)  PID(0)  add
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[0,3] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  Bits needed:[3,32] rf: integer
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(8)  PID(0)  add, 0x00000000 UID(9)  PID(0)  add, 0x00000000 UID(10)  PID(0)  add, 0x00000000 UID(11)  PID(0)  add
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Num to dispatch: 3
@@ -115,14 +118,15 @@
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  to iq0 of target type: INT
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:3    RENAMED 0 pid:0 uopid:0 'add	8,6,7'  stall: INT_BUSY
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:12    RENAMED 0 pid:0 uopid:0 'add	26,24,25' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [25,42] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [43] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:12 BEFORE_FETCH 0 pid:0 uopid:0 'add	26,24,25' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 24 -> 43
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 25 -> 25
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 26 -> 44 from 26
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(12)  PID(0)  add
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(22)  PID(0)  add
 {0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,32] rf: integer
+{0000000005 00000005 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  Bits needed:[5,33] rf: integer
 {0000000005 00000005 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(12)  PID(0)  add
 {0000000005 00000005 top.execute.exe0 info} completeInst_: Completing inst: uid:0  COMPLETED 0 pid:0 uopid:0 'add	2,0,1' 
 {0000000005 00000005 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:1 DISPATCHED 0 pid:0 uopid:0 'add	4,2,3'  to exe_pipe exe0
@@ -133,13 +137,14 @@
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Sending instruction: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  to iq0 of target type: INT
 {0000000005 00000005 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:4    RENAMED 0 pid:0 uopid:0 'add	10,8,9'  stall: INT_BUSY
 {0000000005 00000005 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000005 00000005 top.rename info} renameInstructions_: sending inst to dispatch: uid:13    RENAMED 0 pid:0 uopid:0 'add	28,26,27' 
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [43] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup source register bit mask [27,43] for 'integer' scoreboard
-{0000000005 00000005 top.rename info} renameInstructions_: 	setup destination register bit mask [44] for 'integer' scoreboard
+{0000000005 00000005 top.rename info} renameInstructions_: Renaming uid:13 BEFORE_FETCH 0 pid:0 uopid:0 'add	28,26,27' 
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 26 -> 44
+{0000000005 00000005 top.rename info} renameSources_: 	source rename integer 27 -> 27
+{0000000005 00000005 top.rename info} renameDests_: 	dest rename integer 28 -> 45 from 28
+{0000000005 00000005 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(13)  PID(0)  add
 {0000000005 00000005 top.decode info} inCredits: Got credits from dut: 1
 {0000000005 00000005 top.decode info} Sending group: 0x00000000 UID(23)  PID(0)  add
-{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,33] rf: integer
+{0000000006 00000006 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  Bits needed:[7,34] rf: integer
 {0000000006 00000006 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(13)  PID(0)  add
 {0000000006 00000006 top.execute.exe0 info} executeInst_: Executed inst: uid:1  SCHEDULED 0 pid:0 uopid:0 'add	4,2,3' 
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Num to dispatch: 3
@@ -147,14 +152,15 @@
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Sending instruction: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  to iq0 of target type: INT
 {0000000006 00000006 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:5    RENAMED 0 pid:0 uopid:0 'add	12,10,11'  stall: INT_BUSY
 {0000000006 00000006 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000006 00000006 top.rename info} renameInstructions_: sending inst to dispatch: uid:14    RENAMED 0 pid:0 uopid:0 'add	30,28,29' 
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [44] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup source register bit mask [29,44] for 'integer' scoreboard
-{0000000006 00000006 top.rename info} renameInstructions_: 	setup destination register bit mask [45] for 'integer' scoreboard
+{0000000006 00000006 top.rename info} renameInstructions_: Renaming uid:14 BEFORE_FETCH 0 pid:0 uopid:0 'add	30,28,29' 
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 28 -> 45
+{0000000006 00000006 top.rename info} renameSources_: 	source rename integer 29 -> 29
+{0000000006 00000006 top.rename info} renameDests_: 	dest rename integer 30 -> 46 from 30
+{0000000006 00000006 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(14)  PID(0)  add
 {0000000006 00000006 top.decode info} inCredits: Got credits from dut: 1
 {0000000006 00000006 top.decode info} Sending group: 0x00000000 UID(24)  PID(0)  add
 {0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,34] rf: integer
+{0000000007 00000007 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  Bits needed:[9,35] rf: integer
 {0000000007 00000007 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(14)  PID(0)  add
 {0000000007 00000007 top.execute.exe0 info} completeInst_: Completing inst: uid:1  COMPLETED 0 pid:0 uopid:0 'add	4,2,3' 
 {0000000007 00000007 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:2 DISPATCHED 0 pid:0 uopid:0 'add	6,4,5'  to exe_pipe exe0
@@ -165,12 +171,13 @@
 {0000000007 00000007 top.dispatch info} dispatchInstructions_: Sending instruction: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to iq0 of target type: INT
 {0000000007 00000007 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:6    RENAMED 0 pid:0 uopid:0 'add	14,12,13'  stall: INT_BUSY
 {0000000007 00000007 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000007 00000007 top.rename info} renameInstructions_: sending inst to dispatch: uid:15    RENAMED 0 pid:0 uopid:0 'add	0,30,31' 
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup source register bit mask [45] for 'integer' scoreboard
-{0000000007 00000007 top.rename info} renameInstructions_: 	setup source register bit mask [31,45] for 'integer' scoreboard
+{0000000007 00000007 top.rename info} renameInstructions_: Renaming uid:15 BEFORE_FETCH 0 pid:0 uopid:0 'add	0,30,31' 
+{0000000007 00000007 top.rename info} renameSources_: 	source rename integer 30 -> 46
+{0000000007 00000007 top.rename info} renameSources_: 	source rename integer 31 -> 31
+{0000000007 00000007 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(15)  PID(0)  add
 {0000000007 00000007 top.decode info} inCredits: Got credits from dut: 1
 {0000000007 00000007 top.decode info} Sending group: 0x00000000 UID(25)  PID(0)  add
-{0000000008 00000008 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,35] rf: integer
+{0000000008 00000008 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  Bits needed:[11,36] rf: integer
 {0000000008 00000008 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(15)  PID(0)  add
 {0000000008 00000008 top.execute.exe0 info} executeInst_: Executed inst: uid:2  SCHEDULED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000008 00000008 top.dispatch info} dispatchInstructions_: Num to dispatch: 3
@@ -178,13 +185,14 @@
 {0000000008 00000008 top.dispatch info} dispatchInstructions_: Sending instruction: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  to iq0 of target type: INT
 {0000000008 00000008 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:7    RENAMED 0 pid:0 uopid:0 'add	16,14,15'  stall: INT_BUSY
 {0000000008 00000008 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000008 00000008 top.rename info} renameInstructions_: sending inst to dispatch: uid:16    RENAMED 0 pid:0 uopid:0 'add	2,0,1' 
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000008 00000008 top.rename info} renameInstructions_: 	setup destination register bit mask [46] for 'integer' scoreboard
+{0000000008 00000008 top.rename info} renameInstructions_: Renaming uid:16 BEFORE_FETCH 0 pid:0 uopid:0 'add	2,0,1' 
+{0000000008 00000008 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000008 00000008 top.rename info} renameDests_: 	dest rename integer 2 -> 47 from 32
+{0000000008 00000008 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(16)  PID(0)  add
 {0000000008 00000008 top.decode info} inCredits: Got credits from dut: 1
 {0000000008 00000008 top.decode info} Sending group: 0x00000000 UID(26)  PID(0)  add
 {0000000009 00000009 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000009 00000009 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,36] rf: integer
+{0000000009 00000009 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  Bits needed:[13,37] rf: integer
 {0000000009 00000009 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(16)  PID(0)  add
 {0000000009 00000009 top.execute.exe0 info} completeInst_: Completing inst: uid:2  COMPLETED 0 pid:0 uopid:0 'add	6,4,5' 
 {0000000009 00000009 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:3 DISPATCHED 0 pid:0 uopid:0 'add	8,6,7'  to exe_pipe exe0
@@ -195,13 +203,14 @@
 {0000000009 00000009 top.dispatch info} dispatchInstructions_: Sending instruction: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  to iq0 of target type: INT
 {0000000009 00000009 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:8    RENAMED 0 pid:0 uopid:0 'add	18,16,17'  stall: INT_BUSY
 {0000000009 00000009 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000009 00000009 top.rename info} renameInstructions_: sending inst to dispatch: uid:17    RENAMED 0 pid:0 uopid:0 'add	4,2,3' 
-{0000000009 00000009 top.rename info} renameInstructions_: 	setup source register bit mask [46] for 'integer' scoreboard
-{0000000009 00000009 top.rename info} renameInstructions_: 	setup source register bit mask [3,46] for 'integer' scoreboard
-{0000000009 00000009 top.rename info} renameInstructions_: 	setup destination register bit mask [47] for 'integer' scoreboard
+{0000000009 00000009 top.rename info} renameInstructions_: Renaming uid:17 BEFORE_FETCH 0 pid:0 uopid:0 'add	4,2,3' 
+{0000000009 00000009 top.rename info} renameSources_: 	source rename integer 2 -> 47
+{0000000009 00000009 top.rename info} renameSources_: 	source rename integer 3 -> 3
+{0000000009 00000009 top.rename info} renameDests_: 	dest rename integer 4 -> 48 from 33
+{0000000009 00000009 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(17)  PID(0)  add
 {0000000009 00000009 top.decode info} inCredits: Got credits from dut: 1
 {0000000009 00000009 top.decode info} Sending group: 0x00000000 UID(27)  PID(0)  add
-{0000000010 00000010 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,37] rf: integer
+{0000000010 00000010 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  Bits needed:[15,38] rf: integer
 {0000000010 00000010 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(17)  PID(0)  add
 {0000000010 00000010 top.execute.exe0 info} executeInst_: Executed inst: uid:3  SCHEDULED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000010 00000010 top.dispatch info} dispatchInstructions_: Num to dispatch: 2
@@ -209,14 +218,15 @@
 {0000000010 00000010 top.dispatch info} dispatchInstructions_: Sending instruction: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  to iq0 of target type: INT
 {0000000010 00000010 top.dispatch info} dispatchInstructions_: Could not dispatch: uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19'  stall: INT_BUSY
 {0000000010 00000010 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000010 00000010 top.rename info} renameInstructions_: sending inst to dispatch: uid:18    RENAMED 0 pid:0 uopid:0 'add	6,4,5' 
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup source register bit mask [47] for 'integer' scoreboard
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup source register bit mask [5,47] for 'integer' scoreboard
-{0000000010 00000010 top.rename info} renameInstructions_: 	setup destination register bit mask [48] for 'integer' scoreboard
+{0000000010 00000010 top.rename info} renameInstructions_: Renaming uid:18 BEFORE_FETCH 0 pid:0 uopid:0 'add	6,4,5' 
+{0000000010 00000010 top.rename info} renameSources_: 	source rename integer 4 -> 48
+{0000000010 00000010 top.rename info} renameSources_: 	source rename integer 5 -> 5
+{0000000010 00000010 top.rename info} renameDests_: 	dest rename integer 6 -> 49 from 34
+{0000000010 00000010 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(18)  PID(0)  add
 {0000000010 00000010 top.decode info} inCredits: Got credits from dut: 1
 {0000000010 00000010 top.decode info} Sending group: 0x00000000 UID(28)  PID(0)  add
 {0000000011 00000011 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9' 
-{0000000011 00000011 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,38] rf: integer
+{0000000011 00000011 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  Bits needed:[17,39] rf: integer
 {0000000011 00000011 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(18)  PID(0)  add
 {0000000011 00000011 top.execute.exe0 info} completeInst_: Completing inst: uid:3  COMPLETED 0 pid:0 uopid:0 'add	8,6,7' 
 {0000000011 00000011 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:4 DISPATCHED 0 pid:0 uopid:0 'add	10,8,9'  to exe_pipe exe0
@@ -226,49 +236,51 @@
 {0000000011 00000011 top.dispatch info} acceptInst: iq0: dispatching uid:9    RENAMED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000011 00000011 top.dispatch info} dispatchInstructions_: Sending instruction: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to iq0 of target type: INT
 {0000000011 00000011 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000011 00000011 top.rename info} renameInstructions_: sending inst to dispatch: uid:19    RENAMED 0 pid:0 uopid:0 'add	8,6,7' 
-{0000000011 00000011 top.rename info} renameInstructions_: 	setup source register bit mask [48] for 'integer' scoreboard
-{0000000011 00000011 top.rename info} renameInstructions_: 	setup source register bit mask [7,48] for 'integer' scoreboard
-{0000000011 00000011 top.rename info} renameInstructions_: 	setup destination register bit mask [49] for 'integer' scoreboard
+{0000000011 00000011 top.rename info} renameInstructions_: Renaming uid:19 BEFORE_FETCH 0 pid:0 uopid:0 'add	8,6,7' 
+{0000000011 00000011 top.rename info} renameSources_: 	source rename integer 6 -> 49
+{0000000011 00000011 top.rename info} renameSources_: 	source rename integer 7 -> 7
+{0000000011 00000011 top.rename info} renameDests_: 	dest rename integer 8 -> 50 from 35
+{0000000011 00000011 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(19)  PID(0)  add
 {0000000011 00000011 top.decode info} inCredits: Got credits from dut: 1
 {0000000011 00000011 top.decode info} Sending group: 0x00000000 UID(29)  PID(0)  add
-{0000000012 00000012 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,39] rf: integer
+{0000000012 00000012 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  Bits needed:[19,40] rf: integer
 {0000000012 00000012 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(19)  PID(0)  add
-{0000000012 00000012 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000012 00000012 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000012 00000012 top.execute.exe0 info} executeInst_: Executed inst: uid:4  SCHEDULED 0 pid:0 uopid:0 'add	10,8,9' 
+{0000000012 00000012 top.rename info} scheduleRenaming_: current stall: NO_DISPATCH_CREDITS
 {0000000013 00000013 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000013 00000013 top.execute.exe0 info} completeInst_: Completing inst: uid:4  COMPLETED 0 pid:0 uopid:0 'add	10,8,9' 
 {0000000013 00000013 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:5 DISPATCHED 0 pid:0 uopid:0 'add	12,10,11'  to exe_pipe exe0
 {0000000013 00000013 top.execute.exe0 info} insertInst: Executing: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11'  for 14
 {0000000013 00000013 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 4
-{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000013 00000013 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000014 00000014 top.execute.exe0 info} executeInst_: Executed inst: uid:5  SCHEDULED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000015 00000015 top.execute.exe0 info} completeInst_: Completing inst: uid:5  COMPLETED 0 pid:0 uopid:0 'add	12,10,11' 
 {0000000015 00000015 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:6 DISPATCHED 0 pid:0 uopid:0 'add	14,12,13'  to exe_pipe exe0
 {0000000015 00000015 top.execute.exe0 info} insertInst: Executing: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13'  for 16
 {0000000015 00000015 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 5
-{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000015 00000015 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000016 00000016 top.execute.exe0 info} executeInst_: Executed inst: uid:6  SCHEDULED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000017 00000017 top.execute.exe0 info} completeInst_: Completing inst: uid:6  COMPLETED 0 pid:0 uopid:0 'add	14,12,13' 
 {0000000017 00000017 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:7 DISPATCHED 0 pid:0 uopid:0 'add	16,14,15'  to exe_pipe exe0
 {0000000017 00000017 top.execute.exe0 info} insertInst: Executing: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15'  for 18
 {0000000017 00000017 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 6
-{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000017 00000017 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000018 00000018 top.execute.exe0 info} executeInst_: Executed inst: uid:7  SCHEDULED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000019 00000019 top.execute.exe0 info} completeInst_: Completing inst: uid:7  COMPLETED 0 pid:0 uopid:0 'add	16,14,15' 
 {0000000019 00000019 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:8 DISPATCHED 0 pid:0 uopid:0 'add	18,16,17'  to exe_pipe exe0
 {0000000019 00000019 top.execute.exe0 info} insertInst: Executing: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17'  for 20
 {0000000019 00000019 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 7
-{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000019 00000019 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000020 00000020 top.execute.exe0 info} executeInst_: Executed inst: uid:8  SCHEDULED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000021 00000021 top.execute.exe0 info} completeInst_: Completing inst: uid:8  COMPLETED 0 pid:0 uopid:0 'add	18,16,17' 
 {0000000021 00000021 top.execute.iq0 info} sendReadyInsts_: Sending instruction uid:9 DISPATCHED 0 pid:0 uopid:0 'add	20,18,19'  to exe_pipe exe0
 {0000000021 00000021 top.execute.exe0 info} insertInst: Executing: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19'  for 22
 {0000000021 00000021 top.dispatch info} receiveCredits_: iq0 got 1 credits, total: 8
-{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000021 00000021 top.dispatch info} scheduleDispatchSession: no rob credits
 {0000000022 00000022 top.execute.exe0 info} executeInst_: Executed inst: uid:9  SCHEDULED 0 pid:0 uopid:0 'add	20,18,19' 
 {0000000023 00000023 top.execute.exe0 info} completeInst_: Completing inst: uid:9  COMPLETED 0 pid:0 uopid:0 'add	20,18,19' 

--- a/test/core/rename/Rename_test.cpp
+++ b/test/core/rename/Rename_test.cpp
@@ -32,127 +32,167 @@
 
 TEST_INIT
 
-class olympia::RenameTester {
+class olympia::RenameTester
+{
 public:
-  void test_clearing_rename_structures(olympia::Rename &rename) {
-    // after all instructions have retired, we should have:
-    // num_rename_registers - 31 registers = freelist size
-    // because we initialize the first 31 registers (x1-x31) for integer
-    if (rename.reference_counter_[0].size() == 34) {
-      EXPECT_TRUE(rename.freelist_[0].size() == 3);
-      // in the case of only two free PRFs, they should NOT be equal to each
-      // other
-      EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
-    } else {
-      EXPECT_TRUE(rename.freelist_[0].size() == 97);
+    void test_clearing_rename_structures(const olympia::Rename & rename)
+    {
+        const auto & rf_components = rename.regfile_components_[0];
+        // after all instructions have retired, we should have:
+        // num_rename_registers - 31 registers = freelist size
+        // because we initialize the first 31 registers (x1-x31) for integer
+        if (rf_components.reference_counter.size() == 34)
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 2);
+            // in the case of only two free PRFs, they should NOT be equal to each
+            // other
+            EXPECT_TRUE(rf_components.freelist.front() != rf_components.freelist.back());
+        }
+        else
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 96);
+        }
+        // we're only expecting one reference
+        EXPECT_EQUAL(rf_components.reference_counter[1].cnt, 1);
+        EXPECT_EQUAL(rf_components.reference_counter[2].cnt, 1);
     }
-    // we're only expecting one reference
-    EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
-    EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
-  }
-  void test_clearing_rename_structures_amoadd(olympia::Rename &rename) {
-    // after all instructions have retired, we should have:
-    // num_rename_registers - 32 registers = freelist size
-    // because we initialize the first 32 registers
-    if (rename.reference_counter_[0].size() == 34) {
-      EXPECT_TRUE(rename.freelist_[0].size() == 3);
-      // in the case of only two free PRFs, they should NOT be equal to each
-      // other
-      EXPECT_TRUE(rename.freelist_[0].front() != rename.freelist_[0].back());
-    } else {
-      EXPECT_TRUE(rename.freelist_[0].size() == 96);
-    }
-    // we're only expecting one reference
-    EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
-    EXPECT_TRUE(rename.reference_counter_[0][2] == 0);
-  }
-  void test_one_instruction(olympia::Rename &rename) {
-    // process only one instruction, check that freelist and map_tables are
-    // allocated correctly
-    if (rename.reference_counter_[0].size() == 34) {
-      EXPECT_TRUE(rename.freelist_[0].size() == 2);
-    } else {
-      EXPECT_TRUE(rename.freelist_[0].size() == 96);
-    }
-    // map table entry is valid, as it's been allocated
 
-    // reference counters should now be 2 because the first instruction is:
-    // ADD x3 x1 x2 and both x1 -> prf1 and x2 -> prf2
-    EXPECT_TRUE(rename.reference_counter_[0][1] == 2);
-    EXPECT_TRUE(rename.reference_counter_[0][2] == 2);
-  }
-  void test_multiple_instructions(olympia::Rename &rename) {
-    // first two instructions are RAW
-    // so the second instruction should increase reference count
-    EXPECT_TRUE(rename.reference_counter_[0][2] == 3);
-  }
-  void test_startup_rename_structures(olympia::Rename &rename) {
-    // before starting, we should have:
-    // num_rename_registers - 32 registers = freelist size
-    // because we initialize the first 32 registers
-    if (rename.reference_counter_[0].size() == 34) {
-      EXPECT_TRUE(rename.freelist_[0].size() == 3);
-    } else {
-      EXPECT_TRUE(rename.freelist_[0].size() == 97);
+    void test_clearing_rename_structures_amoadd(const olympia::Rename & rename)
+    {
+        const auto & rf_components = rename.regfile_components_[0];
+        // after all instructions have retired, we should have:
+        // num_rename_registers - 32 registers = freelist size
+        // because we initialize the first 32 registers
+        if (rf_components.reference_counter.size() == 34)
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 2);
+            // in the case of only two free PRFs, they should NOT be equal to each
+            // other
+            EXPECT_TRUE(rf_components.freelist.front() != rf_components.freelist.back());
+        }
+        else
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 96);
+        }
+        // The bottom 3 references should be cleared (amoadd returns)
+        EXPECT_EQUAL(rf_components.reference_counter[0].cnt, 0);
+        EXPECT_EQUAL(rf_components.reference_counter[1].cnt, 0);
+        EXPECT_EQUAL(rf_components.reference_counter[2].cnt, 0);
+        EXPECT_EQUAL(rf_components.reference_counter[3].cnt, 1);
     }
-    // we're only expecting a value of 1 for registers x0 -> x31 because we
-    // initialize them
-    EXPECT_TRUE(rename.reference_counter_[0][1] == 1);
-    EXPECT_TRUE(rename.reference_counter_[0][2] == 1);
-    EXPECT_TRUE(rename.reference_counter_[0][30] == 1);
-    EXPECT_TRUE(rename.reference_counter_[0][31] == 1);
-    // x0 for RF_INTEGER should be not assigned because x0 for RF_INTEGER doesn't use physical registerfile
-    // since it's hardcoded to 0, no need to rename, so we get an extra free register back. Test to make sure
-    // this is actually modeled
-    EXPECT_TRUE(rename.reference_counter_[0][0] == 0);
-    EXPECT_TRUE(rename.reference_counter_[0][32] == 0);
-    EXPECT_TRUE(rename.reference_counter_[0][33] == 0);
-  }
-  void test_float(olympia::Rename &rename) {
-    // ensure the correct register file is used
-    EXPECT_TRUE(rename.freelist_[1].size() == 94);
-    EXPECT_TRUE(rename.freelist_[0].size() == 97);
-  }
+
+    void test_one_instruction(const olympia::Rename & rename)
+    {
+        const auto & rf_components = rename.regfile_components_[0];
+        // process only one instruction, check that freelist and map_tables are
+        // allocated correctly
+        if (rf_components.reference_counter.size() == 34)
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 1);
+        }
+        else
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 95);
+        }
+        // map table entry is valid, as it's been allocated
+
+        // reference counters should now be 2 because the first instruction is:
+        // ADD x3 x1 x2 and both x1 -> prf1 and x2 -> prf2
+        EXPECT_EQUAL(rf_components.reference_counter[1].cnt, 1);
+        EXPECT_EQUAL(rf_components.reference_counter[2].cnt, 1);
+    }
+
+    void test_multiple_instructions(const olympia::Rename & rename)
+    {
+        const auto & rf_components = rename.regfile_components_[0];
+        // first two instructions are RAW
+        // so the second instruction should increase reference count
+        EXPECT_EQUAL(rf_components.reference_counter[2].cnt, 1);
+    }
+
+    void test_startup_rename_structures(const olympia::Rename & rename)
+    {
+        const auto & rf_components = rename.regfile_components_[0];
+        // before starting, we should have:
+        // num_rename_registers - 32 registers = freelist size
+        // because we initialize the first 32 registers
+        if (rf_components.reference_counter.size() == 34)
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 2);
+        }
+        else
+        {
+            EXPECT_EQUAL(rf_components.freelist.size(), 96);
+        }
+        // we're only expecting a value of 1 for registers x0 -> x31 because we
+        // initialize them
+        EXPECT_EQUAL(rf_components.reference_counter[1].cnt, 1);
+        EXPECT_EQUAL(rf_components.reference_counter[2].cnt, 1);
+        EXPECT_EQUAL(rf_components.reference_counter[30].cnt, 1);
+        EXPECT_EQUAL(rf_components.reference_counter[31].cnt, 1);
+        // x0 for RF_INTEGER should be not assigned because x0 for RF_INTEGER doesn't use physical
+        // registerfile since it's hardcoded to 0, no need to rename, so we get an extra free
+        // register back. Test to make sure this is actually modeled
+        EXPECT_EQUAL(rf_components.reference_counter[0].cnt, 0);
+        EXPECT_EQUAL(rf_components.reference_counter[32].cnt, 0);
+        EXPECT_EQUAL(rf_components.reference_counter[33].cnt, 0);
+    }
+
+    void test_float(const olympia::Rename & rename)
+    {
+        const auto & rf_components_0 = rename.regfile_components_[0];
+        const auto & rf_components_1 = rename.regfile_components_[1];
+
+        // ensure the correct register file is used
+        EXPECT_EQUAL(rf_components_1.freelist.size(), 94);
+        EXPECT_EQUAL(rf_components_0.freelist.size(), 96);
+    }
 };
 
-class olympia::IssueQueueTester {
+class olympia::IssueQueueTester
+{
 public:
-  void
-  test_dependent_integer_first_instruction(olympia::IssueQueue &issuequeue) {
-    // testing RAW dependency for ExecutePipe
-    // only alu0 should have an issued instruction
-    // so alu0's total_insts_issued should be 1
-    EXPECT_TRUE(issuequeue.total_insts_issued_ == 1);
-  }
-  void
-  test_dependent_integer_second_instruction(olympia::IssueQueue &issuequeue) {
-    // testing RAW dependency for ExecutePipe
-    // only alu0 should have an issued instruction
-    // alu1 shouldn't, hence this test is checking for alu1's issued inst count
-    // is 0
-    EXPECT_TRUE(issuequeue.total_insts_issued_ == 0);
-  }
+    void test_dependent_integer_first_instruction(olympia::IssueQueue & issuequeue)
+    {
+        // testing RAW dependency for ExecutePipe
+        // only alu0 should have an issued instruction
+        // so alu0's total_insts_issued should be 1
+        EXPECT_EQUAL(issuequeue.total_insts_issued_, 1);
+    }
+
+    void test_dependent_integer_second_instruction(olympia::IssueQueue & issuequeue)
+    {
+        // testing RAW dependency for ExecutePipe
+        // only alu0 should have an issued instruction
+        // alu1 shouldn't, hence this test is checking for alu1's issued inst count
+        // is 0
+        EXPECT_EQUAL(issuequeue.total_insts_issued_, 0);
+    }
 };
 
-class olympia::LSUTester {
+class olympia::LSUTester
+{
 public:
-  void test_dependent_lsu_instruction(olympia::LSU &lsu) {
-    // testing RAW dependency for LSU
-    // we have an ADD instruction before we destination register 3
-    // and then a subsequent STORE instruction to register 3
-    // we can't STORE until the add instruction runs, so we test
-    // while the ADD instruction is running, the STORE instruction should NOT
-    // issue
-    EXPECT_TRUE(lsu.lsu_insts_issued_ == 0);
-  }
-
-  void clear_entries(olympia::LSU &lsu) {
-    auto iter = lsu.ldst_inst_queue_.begin();
-    while (iter != lsu.ldst_inst_queue_.end()) {
-      auto x(iter++);
-      lsu.ldst_inst_queue_.erase(x);
+    void test_dependent_lsu_instruction(olympia::LSU & lsu)
+    {
+        // testing RAW dependency for LSU
+        // we have an ADD instruction before we destination register 3
+        // and then a subsequent STORE instruction to register 3
+        // we can't STORE until the add instruction runs, so we test
+        // while the ADD instruction is running, the STORE instruction should NOT
+        // issue
+        EXPECT_EQUAL(lsu.lsu_insts_issued_, 0);
     }
-  }
+
+    void clear_entries(olympia::LSU & lsu)
+    {
+        auto iter = lsu.ldst_inst_queue_.begin();
+        while (iter != lsu.ldst_inst_queue_.end())
+        {
+            auto x(iter++);
+            lsu.ldst_inst_queue_.erase(x);
+        }
+    }
 };
 
 //
@@ -160,362 +200,357 @@ public:
 //
 // SourceUnit -> Decode -> Rename -> Dispatch -> 1..* SinkUnits
 //
-class RenameSim : public sparta::app::Simulation {
+class RenameSim : public sparta::app::Simulation
+{
 public:
-  RenameSim(sparta::Scheduler *sched, const std::string &mavis_isa_files,
-            const std::string &mavis_uarch_files,
-            const std::string &output_file, const std::string &input_file)
-      : sparta::app::Simulation("RenameSim", sched), input_file_(input_file),
-        test_tap_(getRoot(), "info", output_file) {}
+    RenameSim(sparta::Scheduler* sched, const std::string & mavis_isa_files,
+              const std::string & mavis_uarch_files, const std::string & output_file,
+              const std::string & input_file) :
+        sparta::app::Simulation("RenameSim", sched),
+        input_file_(input_file),
+        test_tap_(getRoot(), "info", output_file)
+    {
+    }
 
-  ~RenameSim() { getRoot()->enterTeardown(); }
+    ~RenameSim() { getRoot()->enterTeardown(); }
 
-  void runRaw(uint64_t run_time) override final {
-    (void)run_time; // ignored
+    void runRaw(uint64_t run_time) override final
+    {
+        (void)run_time; // ignored
 
-    sparta::app::Simulation::runRaw(run_time);
-  }
+        sparta::app::Simulation::runRaw(run_time);
+    }
 
 private:
-  void buildTree_() override {
-    auto rtn = getRoot();
-    // Cerate the common Allocators
-    allocators_tn_.reset(new olympia::OlympiaAllocators(rtn));
-
-    sparta::ResourceTreeNode *disp = nullptr;
-
-    // Create a Mavis Unit
-    tns_to_delete_.emplace_back(new sparta::ResourceTreeNode(
-        rtn, olympia::MavisUnit::name, sparta::TreeNode::GROUP_NAME_NONE,
-        sparta::TreeNode::GROUP_IDX_NONE, "Mavis Unit", &mavis_fact));
-
-    // Create a Source Unit -- this would represent Rename
-    // sparta::ResourceTreeNode * src_unit  = nullptr;
-    // tns_to_delete_.emplace_back(src_unit = new sparta::ResourceTreeNode(rtn,
-    //                                                                     core_test::SourceUnit::name,
-    //                                                                     sparta::TreeNode::GROUP_NAME_NONE,
-    //                                                                     sparta::TreeNode::GROUP_IDX_NONE,
-    //                                                                     "Source
-    //                                                                     Unit",
-    //                                                                     &source_fact));
-    // src_unit->getParameterSet()->getParameter("input_file")->setValueFromString(input_file_);
-    sparta::ResourceTreeNode *decode_unit = nullptr;
-    tns_to_delete_.emplace_back(
-        decode_unit = new sparta::ResourceTreeNode(
-            rtn, olympia::Decode::name, sparta::TreeNode::GROUP_NAME_NONE,
-            sparta::TreeNode::GROUP_IDX_NONE, "Decode Unit", &source_fact));
-    decode_unit->getParameterSet()
-        ->getParameter("input_file")
-        ->setValueFromString(input_file_);
-    // Create Dispatch
-    tns_to_delete_.emplace_back(
-        disp = new sparta::ResourceTreeNode(
-            rtn, olympia::Dispatch::name, sparta::TreeNode::GROUP_NAME_NONE,
-            sparta::TreeNode::GROUP_IDX_NONE, "Test Dispatch", &dispatch_fact));
-
-    // Create Execute -> ExecutePipes and IssueQueues
-    sparta::ResourceTreeNode *execute_unit = new sparta::ResourceTreeNode(
-        rtn, olympia::Execute::name, sparta::TreeNode::GROUP_NAME_NONE,
-        sparta::TreeNode::GROUP_IDX_NONE, "Test Rename", &execute_factory_);
-    tns_to_delete_.emplace_back(execute_unit);
-    // Create Rename
-    sparta::ResourceTreeNode *rename_unit = new sparta::ResourceTreeNode(
-        rtn, olympia::Rename::name, sparta::TreeNode::GROUP_NAME_NONE,
-        sparta::TreeNode::GROUP_IDX_NONE, "Test Rename", &rename_fact);
-    tns_to_delete_.emplace_back(rename_unit);
-    // Create SinkUnit that represents the ROB
-    sparta::ResourceTreeNode *rob = nullptr;
-    tns_to_delete_.emplace_back(
-        rob = new sparta::ResourceTreeNode(
-            rtn, "rob", sparta::TreeNode::GROUP_NAME_NONE,
-            sparta::TreeNode::GROUP_IDX_NONE, "ROB Unit", &rob_fact_));
-    // auto * rob_params = rob->getParameterSet();
-    //  Set the "ROB" to accept a group of instructions
-    // rob_params->getParameter("purpose")->setValueFromString("single");
-
-    // Must add the CoreExtensions factory so the simulator knows
-    // how to interpret the config file extension parameter.
-    // Otherwise, the framework will add any "unnamed" extensions
-    // as strings.
-    rtn->addExtensionFactory(olympia::CoreExtensions::name,
-                             [&]() -> sparta::TreeNode::ExtensionsBase * {
-                               return new olympia::CoreExtensions();
-                             });
-
-    sparta::ResourceTreeNode *exe_unit = nullptr;
-    //
-
-    // Create the LSU sink separately
-    tns_to_delete_.emplace_back(
-        exe_unit = new sparta::ResourceTreeNode(
-            rtn, "lsu", sparta::TreeNode::GROUP_NAME_NONE,
-            sparta::TreeNode::GROUP_IDX_NONE, "Sink Unit", &sink_fact));
-    auto *exe_params = exe_unit->getParameterSet();
-    exe_params->getParameter("purpose")->setValueFromString("single");
-  }
-
-  void configureTree_() override {}
-
-  void bindTree_() override {
-    auto *root_node = getRoot();
-    // Bind the "ROB" (simple SinkUnit that accepts instruction
-    // groups) to Dispatch
-
-    sparta::bind(root_node->getChildAs<sparta::Port>(
-                     "dispatch.ports.out_reorder_buffer_write"),
-                 root_node->getChildAs<sparta::Port>(
-                     "rob.ports.in_reorder_buffer_write"));
-
-    sparta::bind(root_node->getChildAs<sparta::Port>(
-                     "dispatch.ports.in_reorder_buffer_credits"),
-                 root_node->getChildAs<sparta::Port>(
-                     "rob.ports.out_reorder_buffer_credits"));
-
-    // Bind the Rename ports
-    sparta::bind(root_node->getChildAs<sparta::Port>(
-                     "rename.ports.out_dispatch_queue_write"),
-                 root_node->getChildAs<sparta::Port>(
-                     "dispatch.ports.in_dispatch_queue_write"));
-
-    sparta::bind(root_node->getChildAs<sparta::Port>(
-                     "rename.ports.in_dispatch_queue_credits"),
-                 root_node->getChildAs<sparta::Port>(
-                     "dispatch.ports.out_dispatch_queue_credits"));
-
-    sparta::bind(root_node->getChildAs<sparta::Port>("decode.ports.in_credits"),
-                 root_node->getChildAs<sparta::Port>(
-                     "rename.ports.out_uop_queue_credits"));
-    sparta::bind(
-        root_node->getChildAs<sparta::Port>("rename.ports.in_uop_queue_append"),
-        root_node->getChildAs<sparta::Port>("decode.ports.out_instgrp_write"));
-
-    sparta::bind(root_node->getChildAs<sparta::Port>(
-                     "rename.ports.in_rename_retire_ack"),
-                 root_node->getChildAs<sparta::Port>(
-                     "rob.ports.out_rob_retire_ack_rename"));
-
-    const std::string dispatch_ports = "dispatch.ports";
-    const std::string flushmanager_ports = "flushmanager.ports";
-    auto issue_queue_to_pipe_map =
-        olympia::coreutils::getPipeTopology(root_node, "issue_queue_to_pipe_map");
-    auto bind_ports = [root_node](const std::string & left, const std::string & right)
+    void buildTree_() override
     {
-        sparta::bind(root_node->getChildAs<sparta::Port>(left),
-                      root_node->getChildAs<sparta::Port>(right));
-    };
-    for (size_t i = 0; i < issue_queue_to_pipe_map.size(); ++i)
-    {
-        auto iq = issue_queue_to_pipe_map[i];
-        std::string unit_name = "iq" + std::to_string(i);
-        const std::string exe_credits_out =
-            "execute." + unit_name + ".ports.out_scheduler_credits";
-        const std::string disp_credits_in = dispatch_ports + ".in_" + unit_name + "_credits";
-        bind_ports(exe_credits_out, disp_credits_in);
+        auto rtn = getRoot();
+        // Cerate the common Allocators
+        allocators_tn_.reset(new olympia::OlympiaAllocators(rtn));
 
-        // Bind instruction transfer
-        const std::string exe_inst_in = "execute." + unit_name + ".ports.in_execute_write";
-        const std::string disp_inst_out = dispatch_ports + ".out_" + unit_name + "_write";
-        bind_ports(exe_inst_in, disp_inst_out);
-        // in_execute_pipe
-        const std::string exe_pipe_in = "execute." + unit_name + ".ports.in_execute_pipe";
+        sparta::ResourceTreeNode* disp = nullptr;
 
-        auto pipe_target_start = stoi(iq[0]);
-        auto pipe_target_end = stoi(iq[0]);
-        if(iq.size() > 1){
-            pipe_target_end = stoi(iq[1]);
-        }
-        pipe_target_end++;
-        for(int pipe_idx = pipe_target_start; pipe_idx < pipe_target_end; ++pipe_idx){
-            const std::string exe_pipe_out = "execute.exe" + std::to_string(pipe_idx) + ".ports.out_execute_pipe";
-            bind_ports(exe_pipe_in, exe_pipe_out);
-        }
+        // Create a Mavis Unit
+        tns_to_delete_.emplace_back(new sparta::ResourceTreeNode(
+                                        rtn, olympia::MavisUnit::name, sparta::TreeNode::GROUP_NAME_NONE,
+                                        sparta::TreeNode::GROUP_IDX_NONE, "Mavis Unit", &mavis_fact));
+
+        // Create a Source Unit -- this would represent Rename
+        // sparta::ResourceTreeNode * src_unit  = nullptr;
+        // tns_to_delete_.emplace_back(src_unit = new sparta::ResourceTreeNode(rtn,
+        //                                                                     core_test::SourceUnit::name,
+        //                                                                     sparta::TreeNode::GROUP_NAME_NONE,
+        //                                                                     sparta::TreeNode::GROUP_IDX_NONE,
+        //                                                                     "Source
+        //                                                                     Unit",
+        //                                                                     &source_fact));
+        // src_unit->getParameterSet()->getParameter("input_file")->setValueFromString(input_file_);
+        sparta::ResourceTreeNode* decode_unit = nullptr;
+        tns_to_delete_.emplace_back(
+            decode_unit = new sparta::ResourceTreeNode(
+                rtn, olympia::Decode::name, sparta::TreeNode::GROUP_NAME_NONE,
+                sparta::TreeNode::GROUP_IDX_NONE, "Decode Unit", &source_fact));
+        decode_unit->getParameterSet()->getParameter("input_file")->setValueFromString(input_file_);
+        // Create Dispatch
+        tns_to_delete_.emplace_back(
+            disp = new sparta::ResourceTreeNode(
+                rtn, olympia::Dispatch::name, sparta::TreeNode::GROUP_NAME_NONE,
+                sparta::TreeNode::GROUP_IDX_NONE, "Test Dispatch", &dispatch_fact));
+
+        // Create Execute -> ExecutePipes and IssueQueues
+        sparta::ResourceTreeNode* execute_unit = new sparta::ResourceTreeNode(
+            rtn, olympia::Execute::name, sparta::TreeNode::GROUP_NAME_NONE,
+            sparta::TreeNode::GROUP_IDX_NONE, "Test Rename", &execute_factory_);
+        tns_to_delete_.emplace_back(execute_unit);
+        // Create Rename
+        sparta::ResourceTreeNode* rename_unit = new sparta::ResourceTreeNode(
+            rtn, olympia::Rename::name, sparta::TreeNode::GROUP_NAME_NONE,
+            sparta::TreeNode::GROUP_IDX_NONE, "Test Rename", &rename_fact);
+        tns_to_delete_.emplace_back(rename_unit);
+        // Create SinkUnit that represents the ROB
+        sparta::ResourceTreeNode* rob = nullptr;
+        tns_to_delete_.emplace_back(rob = new sparta::ResourceTreeNode(
+                                        rtn, "rob", sparta::TreeNode::GROUP_NAME_NONE,
+                                        sparta::TreeNode::GROUP_IDX_NONE, "ROB Unit", &rob_fact_));
+        // auto * rob_params = rob->getParameterSet();
+        //  Set the "ROB" to accept a group of instructions
+        // rob_params->getParameter("purpose")->setValueFromString("single");
+
+        // Must add the CoreExtensions factory so the simulator knows
+        // how to interpret the config file extension parameter.
+        // Otherwise, the framework will add any "unnamed" extensions
+        // as strings.
+        rtn->addExtensionFactory(olympia::CoreExtensions::name,
+                                 [&]() -> sparta::TreeNode::ExtensionsBase*
+                                 { return new olympia::CoreExtensions(); });
+
+        sparta::ResourceTreeNode* exe_unit = nullptr;
+        //
+
+        // Create the LSU sink separately
+        tns_to_delete_.emplace_back(exe_unit = new sparta::ResourceTreeNode(
+                                        rtn, "lsu", sparta::TreeNode::GROUP_NAME_NONE,
+                                        sparta::TreeNode::GROUP_IDX_NONE, "Sink Unit", &sink_fact));
+        auto* exe_params = exe_unit->getParameterSet();
+        exe_params->getParameter("purpose")->setValueFromString("single");
     }
-    // Bind the "LSU" SinkUnit to Dispatch
-    sparta::bind(
-        root_node->getChildAs<sparta::Port>("dispatch.ports.out_lsu_write"),
-        root_node->getChildAs<sparta::Port>("lsu.ports.in_sink_inst"));
 
-    sparta::bind(
-        root_node->getChildAs<sparta::Port>("dispatch.ports.in_lsu_credits"),
-        root_node->getChildAs<sparta::Port>("lsu.ports.out_sink_credits"));
-  }
+    void configureTree_() override {}
 
-  // Allocators.  Last thing to delete
-  std::unique_ptr<olympia::OlympiaAllocators> allocators_tn_;
-  sparta::ResourceFactory<olympia::Decode, olympia::Decode::DecodeParameterSet>
-      decode_fact;
-  olympia::DispatchFactory dispatch_fact;
-  olympia::IssueQueueFactory issue_queue_fact_;
-  olympia::MavisFactory mavis_fact;
-  olympia::RenameFactory rename_fact;
-  core_test::SourceUnitFactory source_fact;
-  core_test::SinkUnitFactory sink_fact;
-  rename_test::ROBSinkUnitFactory rob_sink_fact;
-  olympia::ExecutePipeFactory execute_pipe_fact_;
-  olympia::ExecuteFactory execute_factory_;
-  sparta::ResourceFactory<olympia::ROB, olympia::ROB::ROBParameterSet>
-      rob_fact_;
+    void bindTree_() override
+    {
+        auto* root_node = getRoot();
+        // Bind the "ROB" (simple SinkUnit that accepts instruction
+        // groups) to Dispatch
 
-  std::vector<std::unique_ptr<sparta::TreeNode>> tns_to_delete_;
-  std::vector<sparta::ResourceTreeNode *> exe_units_;
-  std::vector<std::unique_ptr<sparta::ResourceTreeNode>> issue_queues_;
+        sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.out_reorder_buffer_write"),
+                     root_node->getChildAs<sparta::Port>("rob.ports.in_reorder_buffer_write"));
 
-  const std::string input_file_;
-  sparta::log::Tap test_tap_;
+        sparta::bind(
+            root_node->getChildAs<sparta::Port>("dispatch.ports.in_reorder_buffer_credits"),
+            root_node->getChildAs<sparta::Port>("rob.ports.out_reorder_buffer_credits"));
+
+        // Bind the Rename ports
+        sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.out_dispatch_queue_write"),
+                     root_node->getChildAs<sparta::Port>("dispatch.ports.in_dispatch_queue_write"));
+
+        sparta::bind(
+            root_node->getChildAs<sparta::Port>("rename.ports.in_dispatch_queue_credits"),
+            root_node->getChildAs<sparta::Port>("dispatch.ports.out_dispatch_queue_credits"));
+
+        sparta::bind(root_node->getChildAs<sparta::Port>("decode.ports.in_credits"),
+                     root_node->getChildAs<sparta::Port>("rename.ports.out_uop_queue_credits"));
+        sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.in_uop_queue_append"),
+                     root_node->getChildAs<sparta::Port>("decode.ports.out_instgrp_write"));
+
+        sparta::bind(root_node->getChildAs<sparta::Port>("rename.ports.in_rename_retire_ack"),
+                     root_node->getChildAs<sparta::Port>("rob.ports.out_rob_retire_ack_rename"));
+
+        const std::string dispatch_ports = "dispatch.ports";
+        const std::string flushmanager_ports = "flushmanager.ports";
+        auto issue_queue_to_pipe_map =
+            olympia::coreutils::getPipeTopology(root_node, "issue_queue_to_pipe_map");
+        auto bind_ports = [root_node](const std::string & left, const std::string & right)
+        {
+            sparta::bind(root_node->getChildAs<sparta::Port>(left),
+                         root_node->getChildAs<sparta::Port>(right));
+        };
+        for (size_t i = 0; i < issue_queue_to_pipe_map.size(); ++i)
+        {
+            auto iq = issue_queue_to_pipe_map[i];
+            std::string unit_name = "iq" + std::to_string(i);
+            const std::string exe_credits_out =
+                "execute." + unit_name + ".ports.out_scheduler_credits";
+            const std::string disp_credits_in = dispatch_ports + ".in_" + unit_name + "_credits";
+            bind_ports(exe_credits_out, disp_credits_in);
+
+            // Bind instruction transfer
+            const std::string exe_inst_in = "execute." + unit_name + ".ports.in_execute_write";
+            const std::string disp_inst_out = dispatch_ports + ".out_" + unit_name + "_write";
+            bind_ports(exe_inst_in, disp_inst_out);
+            // in_execute_pipe
+            const std::string exe_pipe_in = "execute." + unit_name + ".ports.in_execute_pipe";
+
+            auto pipe_target_start = stoi(iq[0]);
+            auto pipe_target_end = stoi(iq[0]);
+            if (iq.size() > 1)
+            {
+                pipe_target_end = stoi(iq[1]);
+            }
+            pipe_target_end++;
+            for (int pipe_idx = pipe_target_start; pipe_idx < pipe_target_end; ++pipe_idx)
+            {
+                const std::string exe_pipe_out =
+                    "execute.exe" + std::to_string(pipe_idx) + ".ports.out_execute_pipe";
+                bind_ports(exe_pipe_in, exe_pipe_out);
+            }
+        }
+        // Bind the "LSU" SinkUnit to Dispatch
+        sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.out_lsu_write"),
+                     root_node->getChildAs<sparta::Port>("lsu.ports.in_sink_inst"));
+
+        sparta::bind(root_node->getChildAs<sparta::Port>("dispatch.ports.in_lsu_credits"),
+                     root_node->getChildAs<sparta::Port>("lsu.ports.out_sink_credits"));
+    }
+
+    // Allocators.  Last thing to delete
+    std::unique_ptr<olympia::OlympiaAllocators> allocators_tn_;
+    sparta::ResourceFactory<olympia::Decode, olympia::Decode::DecodeParameterSet> decode_fact;
+    olympia::DispatchFactory dispatch_fact;
+    olympia::IssueQueueFactory issue_queue_fact_;
+    olympia::MavisFactory mavis_fact;
+    olympia::RenameFactory rename_fact;
+    core_test::SourceUnitFactory source_fact;
+    core_test::SinkUnitFactory sink_fact;
+    rename_test::ROBSinkUnitFactory rob_sink_fact;
+    olympia::ExecutePipeFactory execute_pipe_fact_;
+    olympia::ExecuteFactory execute_factory_;
+    sparta::ResourceFactory<olympia::ROB, olympia::ROB::ROBParameterSet> rob_fact_;
+
+    std::vector<std::unique_ptr<sparta::TreeNode>> tns_to_delete_;
+    std::vector<sparta::ResourceTreeNode*> exe_units_;
+    std::vector<std::unique_ptr<sparta::ResourceTreeNode>> issue_queues_;
+
+    const std::string input_file_;
+    sparta::log::Tap test_tap_;
 };
 
 const char USAGE[] = "Usage:\n"
-                     "    \n"
-                     "\n";
+    "    \n"
+    "\n";
 
 sparta::app::DefaultValues DEFAULTS;
 
 // The main tester of Rename.  The test is encapsulated in the
 // parameter test_type of the Source unit.
-void runTest(int argc, char **argv) {
-  DEFAULTS.auto_summary_default = "off";
-  std::vector<std::string> datafiles;
-  std::string input_file;
+void runTest(int argc, char** argv)
+{
+    DEFAULTS.auto_summary_default = "off";
+    std::vector<std::string> datafiles;
+    std::string input_file;
 
-  sparta::app::CommandLineSimulator cls(USAGE, DEFAULTS);
-  auto &app_opts = cls.getApplicationOptions();
-  app_opts.add_options()("output_file",
-                         sparta::app::named_value<std::vector<std::string>>(
-                             "output_file", &datafiles),
-                         "Specifies the output file")(
-      "input-file",
-      sparta::app::named_value<std::string>("INPUT_FILE", &input_file)
-          ->default_value(""),
-      "Provide a JSON instruction stream",
-      "Provide a JSON file with instructions to run through Execute");
+    sparta::app::CommandLineSimulator cls(USAGE, DEFAULTS);
+    auto & app_opts = cls.getApplicationOptions();
+    app_opts.add_options()(
+        "output_file",
+        sparta::app::named_value<std::vector<std::string>>("output_file", &datafiles),
+        "Specifies the output file")(
+            "input-file",
+            sparta::app::named_value<std::string>("INPUT_FILE", &input_file)->default_value(""),
+            "Provide a JSON instruction stream",
+            "Provide a JSON file with instructions to run through Execute");
 
-  po::positional_options_description &pos_opts = cls.getPositionalOptions();
-  pos_opts.add("output_file",
-               -1); // example, look for the <data file> at the end
+    po::positional_options_description & pos_opts = cls.getPositionalOptions();
+    pos_opts.add("output_file",
+                 -1); // example, look for the <data file> at the end
 
-  int err_code = 0;
-  if (!cls.parse(argc, argv, err_code)) {
-    sparta_assert(
-        false,
-        "Command line parsing failed"); // Any errors already printed to cerr
-  }
+    int err_code = 0;
+    if (!cls.parse(argc, argv, err_code))
+    {
+        sparta_assert(false,
+                      "Command line parsing failed"); // Any errors already printed to cerr
+    }
 
-  sparta_assert(false == datafiles.empty(),
-                "Need an output file as the last argument of the test");
+    sparta_assert(false == datafiles.empty(),
+                  "Need an output file as the last argument of the test");
 
-  sparta::Scheduler scheduler;
-  uint64_t ilimit = 0;
-  uint32_t num_cores = 1;
-  bool show_factories = false;
-  OlympiaSim sim("simple", scheduler,
-                 num_cores, // cores
-                 input_file, ilimit, show_factories);
+    sparta::Scheduler scheduler;
+    uint64_t ilimit = 0;
+    uint32_t num_cores = 1;
+    bool show_factories = false;
+    OlympiaSim sim("simple", scheduler,
+                   num_cores, // cores
+                   input_file, ilimit, show_factories);
 
-  if (input_file == "raw_integer.json") {
-    cls.populateSimulation(&sim);
-    sparta::RootTreeNode *root_node = sim.getRoot();
+    if (input_file == "raw_integer.json")
+    {
+        cls.populateSimulation(&sim);
+        sparta::RootTreeNode* root_node = sim.getRoot();
 
-    olympia::IssueQueue *my_issuequeue =
-        root_node->getChild("cpu.core0.execute.iq0")
-            ->getResourceAs<olympia::IssueQueue *>();
-    olympia::IssueQueue *my_issuequeue1 =
-        root_node->getChild("cpu.core0.execute.iq1")
-            ->getResourceAs<olympia::IssueQueue *>();
-    olympia::IssueQueueTester issuequeue_tester;
-    cls.runSimulator(&sim, 8);
-    issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
-    issuequeue_tester.test_dependent_integer_second_instruction(
-        *my_issuequeue1);
-  } else if (input_file == "i2f.json") {
-    cls.populateSimulation(&sim);
-    sparta::RootTreeNode *root_node = sim.getRoot();
-    olympia::Rename *my_rename = root_node->getChild("cpu.core0.rename")
-                                     ->getResourceAs<olympia::Rename *>();
+        olympia::IssueQueue* my_issuequeue =
+            root_node->getChild("cpu.core0.execute.iq0")->getResourceAs<olympia::IssueQueue*>();
+        olympia::IssueQueue* my_issuequeue1 =
+            root_node->getChild("cpu.core0.execute.iq1")->getResourceAs<olympia::IssueQueue*>();
+        olympia::IssueQueueTester issuequeue_tester;
+        cls.runSimulator(&sim, 8);
+        issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
+        issuequeue_tester.test_dependent_integer_second_instruction(*my_issuequeue1);
+    }
+    else if (input_file == "i2f.json")
+    {
+        cls.populateSimulation(&sim);
+        sparta::RootTreeNode* root_node = sim.getRoot();
+        olympia::Rename* my_rename =
+            root_node->getChild("cpu.core0.rename")->getResourceAs<olympia::Rename*>();
 
-    olympia::RenameTester rename_tester;
-    // Must stop the simulation before it retires the i2f instructions,
-    // otherwise the register would have been moved back into the freelist
-    cls.runSimulator(&sim, 8);
-    rename_tester.test_float(*my_rename);
-  } else if (input_file == "raw_int_lsu.json") {
-    // testing RAW dependency for address operand
-    cls.populateSimulation(&sim);
-    sparta::RootTreeNode *root_node = sim.getRoot();
+        olympia::RenameTester rename_tester;
+        // Must stop the simulation before it retires the i2f instructions,
+        // otherwise the register would have been moved back into the freelist
+        cls.runSimulator(&sim, 8);
+        rename_tester.test_float(*my_rename);
+    }
+    else if (input_file == "raw_int_lsu.json")
+    {
+        // testing RAW dependency for address operand
+        cls.populateSimulation(&sim);
+        sparta::RootTreeNode* root_node = sim.getRoot();
 
-    olympia::LSU *my_lsu =
-        root_node->getChild("cpu.core0.lsu")->getResourceAs<olympia::LSU *>();
-    olympia::LSUTester lsu_tester;
-    olympia::IssueQueue *my_issuequeue =
-        root_node->getChild("cpu.core0.execute.iq0")
-            ->getResourceAs<olympia::IssueQueue *>();
-    olympia::IssueQueueTester issuequeue_tester;
-    cls.runSimulator(&sim, 8);
-    issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
-    lsu_tester.test_dependent_lsu_instruction(*my_lsu);
-    lsu_tester.clear_entries(*my_lsu);
-  } else if (input_file == "raw_float_lsu.json") {
-    // testing RAW dependency for data operand
-    cls.populateSimulation(&sim);
-    sparta::RootTreeNode *root_node = sim.getRoot();
+        olympia::LSU* my_lsu = root_node->getChild("cpu.core0.lsu")->getResourceAs<olympia::LSU*>();
+        olympia::LSUTester lsu_tester;
+        olympia::IssueQueue* my_issuequeue =
+            root_node->getChild("cpu.core0.execute.iq0")->getResourceAs<olympia::IssueQueue*>();
+        olympia::IssueQueueTester issuequeue_tester;
+        cls.runSimulator(&sim, 8);
+        issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
+        lsu_tester.test_dependent_lsu_instruction(*my_lsu);
+        lsu_tester.clear_entries(*my_lsu);
+    }
+    else if (input_file == "raw_float_lsu.json")
+    {
+        // testing RAW dependency for data operand
+        cls.populateSimulation(&sim);
+        sparta::RootTreeNode* root_node = sim.getRoot();
 
-    olympia::LSU *my_lsu =
-        root_node->getChild("cpu.core0.lsu")->getResourceAs<olympia::LSU *>();
-    olympia::LSUTester lsu_tester;
-    // assuming iq1 is floating point issue queue
-    olympia::IssueQueue *my_issuequeue =
-        root_node->getChild("cpu.core0.execute.iq1")
-            ->getResourceAs<olympia::IssueQueue *>();
-    olympia::IssueQueueTester issuequeue_tester;
-    cls.runSimulator(&sim, 8);
-    issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
-    lsu_tester.test_dependent_lsu_instruction(*my_lsu);
-    lsu_tester.clear_entries(*my_lsu);
-  } else if (input_file.find("amoadd.json") != std::string::npos) {
-    sparta::Scheduler sched;
+        olympia::LSU* my_lsu = root_node->getChild("cpu.core0.lsu")->getResourceAs<olympia::LSU*>();
+        olympia::LSUTester lsu_tester;
+        // assuming iq1 is floating point issue queue
+        olympia::IssueQueue* my_issuequeue =
+            root_node->getChild("cpu.core0.execute.iq1")->getResourceAs<olympia::IssueQueue*>();
+        olympia::IssueQueueTester issuequeue_tester;
+        cls.runSimulator(&sim, 8);
+        issuequeue_tester.test_dependent_integer_first_instruction(*my_issuequeue);
+        lsu_tester.test_dependent_lsu_instruction(*my_lsu);
+        lsu_tester.clear_entries(*my_lsu);
+    }
+    else if (input_file.find("amoadd.json") != std::string::npos)
+    {
+        sparta::Scheduler sched;
 
-    cls.populateSimulation(&sim);
+        cls.populateSimulation(&sim);
 
-    sparta::RootTreeNode *root_node = sim.getRoot();
-    olympia::Rename *my_rename = root_node->getChild("cpu.core0.rename")
-                                     ->getResourceAs<olympia::Rename *>();
-    olympia::RenameTester rename_tester;
-    cls.runSimulator(&sim);
-    rename_tester.test_clearing_rename_structures_amoadd(*my_rename);
-  } else if (input_file.find("rename_multiple_instructions_full.json") !=
-             std::string::npos) {
-    sparta::RootTreeNode *root_node = sim.getRoot();
-    cls.populateSimulation(&sim);
-    cls.runSimulator(&sim);
-    olympia::Rename *my_rename = root_node->getChild("cpu.core0.rename")
-                                     ->getResourceAs<olympia::Rename *>();
-    olympia::RenameTester rename_tester;
-    rename_tester.test_clearing_rename_structures(*my_rename);
-  } else {
-    sparta::Scheduler sched;
-    RenameSim rename_sim(&sched, "mavis_isa_files", "arch/isa_json",
-                         datafiles[0], input_file);
+        sparta::RootTreeNode* root_node = sim.getRoot();
+        olympia::Rename* my_rename =
+            root_node->getChild("cpu.core0.rename")->getResourceAs<olympia::Rename*>();
+        olympia::RenameTester rename_tester;
+        cls.runSimulator(&sim);
+        rename_tester.test_clearing_rename_structures_amoadd(*my_rename);
+    }
+    else if (input_file.find("rename_multiple_instructions_full.json") != std::string::npos)
+    {
+        sparta::RootTreeNode* root_node = sim.getRoot();
+        cls.populateSimulation(&sim);
+        cls.runSimulator(&sim);
+        olympia::Rename* my_rename =
+            root_node->getChild("cpu.core0.rename")->getResourceAs<olympia::Rename*>();
+        olympia::RenameTester rename_tester;
+        rename_tester.test_clearing_rename_structures(*my_rename);
+    }
+    else
+    {
+        sparta::Scheduler sched;
+        RenameSim rename_sim(&sched, "mavis_isa_files", "arch/isa_json", datafiles[0], input_file);
 
-    cls.populateSimulation(&rename_sim);
+        cls.populateSimulation(&rename_sim);
 
-    sparta::RootTreeNode *root_node = rename_sim.getRoot();
-    olympia::Rename *my_rename =
-        root_node->getChild("rename")->getResourceAs<olympia::Rename *>();
-    olympia::RenameTester rename_tester;
-    rename_tester.test_startup_rename_structures(*my_rename);
-    cls.runSimulator(&rename_sim, 2);
-    rename_tester.test_one_instruction(*my_rename);
+        sparta::RootTreeNode* root_node = rename_sim.getRoot();
+        olympia::Rename* my_rename =
+            root_node->getChild("rename")->getResourceAs<olympia::Rename*>();
+        olympia::RenameTester rename_tester;
+        rename_tester.test_startup_rename_structures(*my_rename);
+        cls.runSimulator(&rename_sim, 2);
+        rename_tester.test_one_instruction(*my_rename);
 
-    cls.runSimulator(&rename_sim, 3);
-    rename_tester.test_multiple_instructions(*my_rename);
+        cls.runSimulator(&rename_sim, 3);
+        rename_tester.test_multiple_instructions(*my_rename);
 
-    EXPECT_FILES_EQUAL(datafiles[0],
-                       "expected_output/" + datafiles[0] + ".EXPECTED");
-  }
+        EXPECT_FILES_EQUAL(datafiles[0], "expected_output/" + datafiles[0] + ".EXPECTED");
+    }
 }
 
-int main(int argc, char **argv) {
-  runTest(argc, argv);
+int main(int argc, char** argv)
+{
+    runTest(argc, argv);
 
-  REPORT_ERROR;
-  return (int)ERROR_CODE;
+    REPORT_ERROR;
+    return (int)ERROR_CODE;
 }

--- a/test/core/rename/amoadd.json
+++ b/test/core/rename/amoadd.json
@@ -47,7 +47,7 @@
         "rs1": 2,
         "imm": 4
     },
-    
+
     {
         "mnemonic": "amoadd.w",
         "rs1": 1,

--- a/test/core/rename/expected_output/big_core.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Mar 19 15:06:04 2025
-#Elapsed:  0.002161s
+#Start:    Thursday Thu Mar 20 11:51:15 2025
+#Elapsed:  0.00356s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: DIViq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq1
@@ -32,22 +32,22 @@
 {0000000000 00000000 top.execute.exe8 info} ExecutePipe: ExecutePipe construct: #8
 {0000000000 00000000 top.execute.exe9 info} ExecutePipe: ExecutePipe construct: #9
 {0000000000 00000000 top.execute.exe10 info} ExecutePipe: ExecutePipe construct: #10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 30 credits, total: 30
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq4 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq5 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
@@ -89,7 +89,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: integer
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 

--- a/test/core/rename/expected_output/big_core.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:27:18 2024
-#Elapsed:  0.002659s
+#Start:    Wednesday Wed Mar 19 15:06:04 2025
+#Elapsed:  0.002161s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: DIViq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq1
@@ -51,10 +51,11 @@
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:1 uopid:0 'add	3,1,2' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 3 -> 32 from 3
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -62,10 +63,11 @@
 {0000000002 00000002 top.dispatch info} acceptInst: iq0: dispatching uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2'  to iq0 of target type: INT
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:2 uopid:0 'add	4,3,2' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 3 -> 32
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -80,13 +82,14 @@
 {0000000003 00000003 top.dispatch info} acceptInst: iq0: dispatching uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  to iq0 of target type: INT
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:3 uopid:0 'mul	13,12,11' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 13 -> 34 from 13
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[0,2] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -95,9 +98,10 @@
 {0000000004 00000004 top.dispatch info} acceptInst: iq1: dispatching uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:3 uopid:0 'mul	13,12,11'  to iq1 of target type: MUL
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:4 uopid:0 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:4 uopid:0 'sub	14,13,12' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 13 -> 34
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 14 -> 35 from 14
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub

--- a/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Mar 19 15:08:31 2025
-#Elapsed:  0.002281s
+#Start:    Thursday Thu Mar 20 11:50:33 2025
+#Elapsed:  0.002192s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: DIViq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq1
@@ -32,22 +32,22 @@
 {0000000000 00000000 top.execute.exe8 info} ExecutePipe: ExecutePipe construct: #8
 {0000000000 00000000 top.execute.exe9 info} ExecutePipe: ExecutePipe construct: #9
 {0000000000 00000000 top.execute.exe10 info} ExecutePipe: ExecutePipe construct: #10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 30 credits, total: 30
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq4 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq5 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
@@ -82,7 +82,7 @@
 {0000000003 00000003 top.dispatch info} acceptInst: iq0: dispatching uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  to iq0 of target type: INT
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NO_INTEGER_RENAMES
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: integer
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000004 00000004 top.rob info} retireInstructions_: num to retire: 2

--- a/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
+++ b/test/core/rename/expected_output/big_core_small_rename.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:27:18 2024
-#Elapsed:  0.003002s
+#Start:    Wednesday Wed Mar 19 15:08:31 2025
+#Elapsed:  0.002281s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: DIViq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq1
@@ -51,10 +51,11 @@
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:1 uopid:0 'add	3,1,2' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 3 -> 32 from 3
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -62,10 +63,11 @@
 {0000000002 00000002 top.dispatch info} acceptInst: iq0: dispatching uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2'  to iq0 of target type: INT
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:2 uopid:0 'add	4,3,2' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 3 -> 32
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -79,19 +81,8 @@
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
 {0000000003 00000003 top.dispatch info} acceptInst: iq0: dispatching uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  to iq0 of target type: INT
-{0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
-{0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
-{0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[0,2] rf: integer
+{0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NO_INTEGER_RENAMES
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
-{0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000004 00000004 top.rob info} retireInstructions_: num to retire: 2
-{0000000004 00000004 top.dispatch info} dispatchInstructions_: Num to dispatch: 1
-{0000000004 00000004 top.dispatch info} acceptInst: iq1: dispatching uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
-{0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:3 uopid:0 'mul	13,12,11'  to iq1 of target type: MUL
-{0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NO_RENAMES

--- a/test/core/rename/expected_output/medium_core.out.EXPECTED
+++ b/test/core/rename/expected_output/medium_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:27:18 2024
-#Elapsed:  0.002592s
+#Start:    Wednesday Wed Mar 19 15:05:54 2025
+#Elapsed:  0.002131s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -44,10 +44,11 @@
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:1 uopid:0 'add	3,1,2' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 3 -> 32 from 3
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -55,10 +56,11 @@
 {0000000002 00000002 top.dispatch info} acceptInst: iq0: dispatching uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2'  to iq0 of target type: INT
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:2 uopid:0 'add	4,3,2' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 3 -> 32
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -73,13 +75,14 @@
 {0000000003 00000003 top.dispatch info} acceptInst: iq0: dispatching uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  to iq0 of target type: INT
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:3 uopid:0 'mul	13,12,11' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 13 -> 34 from 13
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[0,2] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -88,9 +91,10 @@
 {0000000004 00000004 top.dispatch info} acceptInst: iq0: dispatching uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:3 uopid:0 'mul	13,12,11'  to iq0 of target type: MUL
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:4 uopid:0 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:4 uopid:0 'sub	14,13,12' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 13 -> 34
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 14 -> 35 from 14
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub

--- a/test/core/rename/expected_output/medium_core.out.EXPECTED
+++ b/test/core/rename/expected_output/medium_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Mar 19 15:05:54 2025
-#Elapsed:  0.002131s
+#Start:    Thursday Thu Mar 20 11:50:33 2025
+#Elapsed:  0.001912s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -27,20 +27,20 @@
 {0000000000 00000000 top.execute.exe4 info} ExecutePipe: ExecutePipe construct: #4
 {0000000000 00000000 top.execute.exe5 info} ExecutePipe: ExecutePipe construct: #5
 {0000000000 00000000 top.execute.exe6 info} ExecutePipe: ExecutePipe construct: #6
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 30 credits, total: 30
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq4 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
@@ -82,7 +82,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: integer
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 

--- a/test/core/rename/expected_output/small_core.out.EXPECTED
+++ b/test/core/rename/expected_output/small_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Wednesday Wed Mar 19 15:02:50 2025
-#Elapsed:  0.001862s
+#Start:    Thursday Thu Mar 20 11:51:15 2025
+#Elapsed:  0.001964s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -23,18 +23,18 @@
 {0000000000 00000000 top.execute.exe1 info} ExecutePipe: ExecutePipe construct: #1
 {0000000000 00000000 top.execute.exe2 info} ExecutePipe: ExecutePipe construct: #2
 {0000000000 00000000 top.execute.exe3 info} ExecutePipe: ExecutePipe construct: #3
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} robCredits_: ROB got 30 credits, total: 30
 {0000000000 00000000 top.dispatch info} receiveCredits_: lsu got 10 credits, total: 10
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq0 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq1 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq2 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.dispatch info} receiveCredits_: iq3 got 8 credits, total: 8
-{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no rob credits or no instructions to process
+{0000000000 00000000 top.dispatch info} scheduleDispatchSession: no instructions to process
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
@@ -76,7 +76,7 @@
 {0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: integer
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 

--- a/test/core/rename/expected_output/small_core.out.EXPECTED
+++ b/test/core/rename/expected_output/small_core.out.EXPECTED
@@ -3,8 +3,8 @@
 #Exe:      
 #SimulatorVersion:
 #Repro:    
-#Start:    Saturday Sat Oct 19 16:27:18 2024
-#Elapsed:  0.002441s
+#Start:    Wednesday Wed Mar 19 15:02:50 2025
+#Elapsed:  0.001862s
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: INTiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: MULiq0
 {0000000000 00000000 top.dispatch info} Dispatch: mapping target: I2Fiq0
@@ -38,10 +38,11 @@
 {0000000000 00000000 top.decode info} inCredits: Got credits from dut: 10
 {0000000000 00000000 top.decode info} Sending group: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000001 00000001 top.rename info} renameInstructions_: sending inst to dispatch: uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup source register bit mask [1-2] for 'integer' scoreboard
-{0000000001 00000001 top.rename info} renameInstructions_: 	setup destination register bit mask [0] for 'integer' scoreboard
+{0000000001 00000001 top.rename info} renameInstructions_: Renaming uid:0 BEFORE_FETCH 0 pid:1 uopid:0 'add	3,1,2' 
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 1 -> 1
+{0000000001 00000001 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000001 00000001 top.rename info} renameDests_: 	dest rename integer 3 -> 32 from 3
+{0000000001 00000001 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(0)  PID(1)  add
 {0000000001 00000001 top.decode info} inCredits: Got credits from dut: 1
 {0000000001 00000001 top.decode info} Sending group: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(0)  PID(1)  add
@@ -49,10 +50,11 @@
 {0000000002 00000002 top.dispatch info} acceptInst: iq0: dispatching uid:0    RENAMED 0 pid:1 uopid:0 'add	3,1,2' 
 {0000000002 00000002 top.dispatch info} dispatchInstructions_: Sending instruction: uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2'  to iq0 of target type: INT
 {0000000002 00000002 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000002 00000002 top.rename info} renameInstructions_: sending inst to dispatch: uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup source register bit mask [0,2] for 'integer' scoreboard
-{0000000002 00000002 top.rename info} renameInstructions_: 	setup destination register bit mask [32] for 'integer' scoreboard
+{0000000002 00000002 top.rename info} renameInstructions_: Renaming uid:1 BEFORE_FETCH 0 pid:2 uopid:0 'add	4,3,2' 
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 3 -> 32
+{0000000002 00000002 top.rename info} renameSources_: 	source rename integer 2 -> 2
+{0000000002 00000002 top.rename info} renameDests_: 	dest rename integer 4 -> 33 from 4
+{0000000002 00000002 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(1)  PID(2)  add
 {0000000002 00000002 top.decode info} inCredits: Got credits from dut: 1
 {0000000002 00000002 top.decode info} Sending group: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.execute.iq0 info} handleOperandIssueCheck_: Sending to issue queue uid:0 DISPATCHED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -67,13 +69,14 @@
 {0000000003 00000003 top.dispatch info} acceptInst: iq0: dispatching uid:1    RENAMED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000003 00000003 top.dispatch info} dispatchInstructions_: Sending instruction: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  to iq0 of target type: INT
 {0000000003 00000003 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000003 00000003 top.rename info} renameInstructions_: sending inst to dispatch: uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup source register bit mask [11-12] for 'integer' scoreboard
-{0000000003 00000003 top.rename info} renameInstructions_: 	setup destination register bit mask [33] for 'integer' scoreboard
+{0000000003 00000003 top.rename info} renameInstructions_: Renaming uid:2 BEFORE_FETCH 0 pid:3 uopid:0 'mul	13,12,11' 
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000003 00000003 top.rename info} renameSources_: 	source rename integer 11 -> 11
+{0000000003 00000003 top.rename info} renameDests_: 	dest rename integer 13 -> 34 from 13
+{0000000003 00000003 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(2)  PID(3)  mul
 {0000000003 00000003 top.decode info} inCredits: Got credits from dut: 1
 {0000000003 00000003 top.decode info} Sending group: 0x00000000 UID(3)  PID(4)  sub
-{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[0,2] rf: integer
+{0000000004 00000004 top.execute.iq0 info} handleOperandIssueCheck_: Instruction NOT ready: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2'  Bits needed:[2,32] rf: 0
 {0000000004 00000004 top.rob info} robAppended_: retire appended: uid:1 DISPATCHED 0 pid:2 uopid:0 'add	4,3,2' 
 {0000000004 00000004 top.dispatch info} dispatchQueueAppended_: queue appended: 0x00000000 UID(2)  PID(3)  mul
 {0000000004 00000004 top.execute.exe0 info} executeInst_: Executed inst: uid:0  SCHEDULED 0 pid:1 uopid:0 'add	3,1,2' 
@@ -82,9 +85,10 @@
 {0000000004 00000004 top.dispatch info} acceptInst: iq0: dispatching uid:2    RENAMED 0 pid:3 uopid:0 'mul	13,12,11' 
 {0000000004 00000004 top.dispatch info} dispatchInstructions_: Sending instruction: uid:2 DISPATCHED 0 pid:3 uopid:0 'mul	13,12,11'  to iq0 of target type: MUL
 {0000000004 00000004 top.rename info} scheduleRenaming_: current stall: NOT_STALLED
-{0000000004 00000004 top.rename info} renameInstructions_: sending inst to dispatch: uid:3    RENAMED 0 pid:4 uopid:0 'sub	14,13,12' 
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup source register bit mask [12,33] for 'integer' scoreboard
-{0000000004 00000004 top.rename info} renameInstructions_: 	setup destination register bit mask [34] for 'integer' scoreboard
+{0000000004 00000004 top.rename info} renameInstructions_: Renaming uid:3 BEFORE_FETCH 0 pid:4 uopid:0 'sub	14,13,12' 
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 13 -> 34
+{0000000004 00000004 top.rename info} renameSources_: 	source rename integer 12 -> 12
+{0000000004 00000004 top.rename info} renameDests_: 	dest rename integer 14 -> 35 from 14
+{0000000004 00000004 top.rename info} renameInstructions_: sending insts to dispatch: 0x00000000 UID(3)  PID(4)  sub
 {0000000004 00000004 top.decode info} inCredits: Got credits from dut: 1
 {0000000004 00000004 top.decode info} Sending group: 0x00000000 UID(4)  PID(5)  sub


### PR DESCRIPTION
Working with the previous Rename code base illustrated a series design issues that I needed to address.

In this PR, I've changed Rename to support the following:

- Move elimination ([example](https://easyperf.net/blog/2018/04/22/What-optimizations-you-can-expect-from-CPU#move-elimination))
- Partial vs full Renaming -- should rename make sure it can rename ALL instructions before renaming any of them?
- Faster resource availability calculation
- A more advanced RenameData structure
- Added ROB-targeted instruction support -- instructions can can "executed" at rename and sent directly to the ROB
- Code cleanup including a run through clang-format for those files that I touched

Keeping this as a draft for now as I need to update documentation and testing.