### PR TITLE
Fix for Fetch Hang (#254)

### DIFF
--- a/core/fetch/Fetch.cpp
+++ b/core/fetch/Fetch.cpp
@@ -260,6 +260,11 @@ namespace olympia
 
         // No longer speculative
         // speculative_path_ = false;
+
+	// Fix for Issue #254
+	// It is possible that we do not have any external trigger to restart
+	// fetch, so force bootstrap it like when initialized
+	ev_fetch_insts->schedule(1);
     }
 
     void Fetch::onROBTerminate_(const bool & stopped)


### PR DESCRIPTION
It was observed that in certain long tests olympia model completed prematurely.

This is because fetch unit is not restarted after flush and in this particular case, there were no credits or other events that triggered fetch to start fetching instructions

Solution is to schedule fetching in next cycle after flush, just as done on initialization