### PR TITLE
Flushing SYS instructions on retire should halt same cycle retires

### DIFF
--- a/core/ROB.cpp
+++ b/core/ROB.cpp
@@ -201,6 +201,12 @@ namespace olympia
                 if (SPARTA_EXPECT_FALSE(ex_inst.getPipe() == InstArchInfo::TargetPipe::SYS))
                 {
                     retireSysInst_(ex_inst_ptr);
+		    // Fix for Issue #253
+                    // If a flush is caused by retiring sys inst, then retire no more!
+                    if (expect_flush_ == true) {
+                       break;
+                   }
+
                 }
             }
             else

--- a/test/sim/CMakeLists.txt
+++ b/test/sim/CMakeLists.txt
@@ -56,6 +56,10 @@ sparta_named_test(olympia_json_test_missing_opcodes olympia
 sparta_named_test(olympia_json_test_fp_transfers olympia
   --workload json_tests/fp_transfers.json)
 
+# Test sys retire under flush (#253)
+sparta_named_test(olympia_json_test_sys_retire_under_flush_issue_253 olympia
+  --workload json_tests/sys_flush_test.json --arch ../arches/big_core.yaml)
+
 # Test PEvent generation
 sparta_named_test(olympia_json_test_pevents olympia
   --workload traces/dhry_riscv.zstf -i100k

--- a/test/sim/json_tests/sys_flush_test.json
+++ b/test/sim/json_tests/sys_flush_test.json
@@ -1,0 +1,296 @@
+[
+  {
+    "CSR": 140,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "CSR": 140,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "CSR": 141,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "CSR": 142,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "CSR": 143,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "CSR": 144,
+    "mnemonic": "csrrs",
+    "rs1": 18,
+    "rs2": 0
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  },
+  {
+    "mnemonic": "mul",
+    "rd": 3,
+    "rs1": 5,
+    "rs2": 2
+  }
+]


### PR DESCRIPTION
Failing test and solution for Issue #253 

Some of the SYS instrutions are executed on retire and may cause a flush. Olympia currently allows the youger uops to retire in the same cycle. 

However, when the flushing sys uop is retired, the program order check fails, as younger uops have retired out of order.

Solution is to stop retiring uops when this happens.