### PR TITLE
draft - support multiple predictions

### DIFF
--- a/core/fetch/BranchPredIF.hpp
+++ b/core/fetch/BranchPredIF.hpp
@@ -22,6 +22,13 @@
  * It is intended that an implementation of branch predictor must also specify
  * implementations of Prediction output, Prediction input and Update input, along with
  * implementations of getPrediction and updatePredictor operations.
+ *
+ * Support for multiple predictions/updates is added parallel to the single 
+ * prediction/update interface
+ * 
+ * A optional signaling interface is proposed for support of prediction override 
+ * in the multi-prediction case
+ * 
  * */
 #pragma once
 
@@ -30,15 +37,43 @@ namespace olympia
 namespace BranchPredictor
 {
 
-    template <class PredictionT, class UpdateT, class InputT>
+    template <class PredictionT, class UpdateT, class InputT, class SignalT>
     class BranchPredictorIF
     {
+      using NInputT = std::vector<InputT>;
+      using NPredictionT = std::vector<PredictionT>;
+      using NUpdateT = std::vector<UpdateT>;
+      using NSignalT = std::map<std::string,SignalT>;
     public:
         // TODO: create constexpr for bytes per compressed and uncompressed inst
         static constexpr uint8_t bytes_per_inst = 4;
-        virtual ~BranchPredictorIF() { };
+        virtual ~BranchPredictorIF() = default;
+
         virtual PredictionT getPrediction(const InputT &) = 0;
         virtual void updatePredictor(const UpdateT &) = 0;
+
+        //N-prediction requests
+        virtual NPredictionT getPrediction(const NInputT &inputs) {
+          std::vector<PredictionT> result;
+          result.reserve(inputs.size());
+          for (const auto &input : inputs)
+              result.push_back(getPrediction(input));
+          return result;
+        }
+
+        //N-update requests
+        virtual void updatePredictor(const NUpdateT &updates) {
+            for (const auto &update : updates)
+                updatePredictor(update);
+        }
+
+        //Optional signal interface for staging predictions
+        virtual std::optional<NSignalT> getSignals() const {
+           return std::nullopt;
+        }
+
+        // Name the predictor
+        virtual std::string getName() const = 0;
     };
 
 } // namespace BranchPredictor


### PR DESCRIPTION
support for multiple prediction requests
support for signaling for stage prediction results and updates

Motivation for signalling is the case of BP clusters with various predictors, with staged results. It is interesting to study the most effective ways to deal with later predictions, the override case., and its impact on MPKI.

I have an example, It would be useful to hear opinions on the best way to do this in olympia.



