### PR TITLE
Docker workflow for STF trace generation

### DIFF
--- a/traces/docker_stf_trace_gen/Dockerfile
+++ b/traces/docker_stf_trace_gen/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+RUN apt-get install -y device-tree-compiler libboost-regex-dev libboost-system-dev git binutils build-essential cmake gcc-riscv64-linux-gnu zstd libzstd-dev autoconf automake autotools-dev curl python3 python3-pip python3-tomli libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+
+RUN mkdir  riscv
+ENV RISCV=/riscv
+ENV PATH=$RISCV/bin:$PATH
+
+RUN git clone https://github.com/jeffnye-gh/riscv-isa-sim.git
+RUN git clone https://github.com/riscv-software-src/riscv-pk.git
+RUN git clone https://github.com/riscv-collab/riscv-gnu-toolchain.git
+
+WORKDIR /riscv-gnu-toolchain
+RUN ./configure --prefix=/opt/riscv
+ENV PATH=/opt/riscv/bin:$PATH
+RUN make -j$(nproc)
+
+WORKDIR /riscv-pk/build
+RUN ../configure --prefix=$RISCV --host=riscv64-unknown-elf
+RUN make  -j$(nproc)
+RUN make install
+
+WORKDIR /riscv-isa-sim/build
+RUN git checkout spike_stf
+RUN git submodule update --init --recursive
+RUN ../configure --prefix=$RISCV
+RUN make -j$(nproc)
+RUN make install

--- a/traces/docker_stf_trace_gen/README.md
+++ b/traces/docker_stf_trace_gen/README.md
@@ -1,0 +1,58 @@
+# Spike-STF trace generation
+
+> This workflow is still under development. For the most up-to-date instructions, refer to this [README](../README.md)
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+1. [Dependencies](#dependencies)
+1. [Project Structure](#project-structure)
+1. [Usage](#usage)
+    1. [Build the Docker Image](#build-the-docker-image)
+    1. [Run STF Trace Generation](#run-stf-trace-generation)
+
+## Introduction
+
+This setup provides a containerized workflow to generate STF traces using Spike-STF. It sets up a complete environment with the RISC-V GNU toolchain, pk (proxy kernel), and Spike-STF.
+
+## Dependencies
+
+- **Docker** – See the [official installation guide](https://docs.docker.com/engine/install).  
+  This workflow was tested with Docker version 28.3.0, build 38b7060, but it should also work with the latest available version.
+
+## Project Structure
+
+```bash
+qemu-simpoint-dhrystone/
+├── Dockerfile               # Creates a Docker image with the RISC-V GNU toolchain, pk, and Spike-STF
+├── run_in_docker.sh         # Runs an STF trace generation example inside the container
+├── build_docker.sh          # Builds the Docker image
+├── build_and_run.sh         # Executes both build_docker and run_in_docker scripts
+```
+
+## Usage
+
+This workflow can be split into two sequential tasks:
+- Build the Docker image
+- Generate STF traces using the Docker container
+
+Alternatively, you may run the [`build_and_run.sh`](./build_and_run.sh) script to see an example of the trace generation process.
+
+### Build the Docker Image
+
+```bash
+docker build -t spike-stf .
+```
+
+### Run STF Trace Generation
+
+```bash
+mkdir -p trace_output
+
+docker run --rm \
+  -v ./trace_output:/output \
+  spike-stf \
+  bash -c "
+    echo '<REPLACE THIS ECHO COMMAND WITH SPIKE STF TRACE GENERATION COMMAND>' >> /output/EXAMPLE.zstf
+  "
+```

--- a/traces/docker_stf_trace_gen/build_and_run.sh
+++ b/traces/docker_stf_trace_gen/build_and_run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# === Configuration ===
+BUILD_SCRIPT="./build_docker.sh"
+RUN_SCRIPT="./run_in_docker.sh"
+
+echo "[STEP 1] Building Docker image..."
+bash "$BUILD_SCRIPT"
+
+echo "[STEP 2] Running BBV generation and SimPoint analysis..."
+bash "$RUN_SCRIPT"

--- a/traces/docker_stf_trace_gen/build_and_run.sh
+++ b/traces/docker_stf_trace_gen/build_and_run.sh
@@ -9,5 +9,5 @@ RUN_SCRIPT="./run_in_docker.sh"
 echo "[STEP 1] Building Docker image..."
 bash "$BUILD_SCRIPT"
 
-echo "[STEP 2] Running BBV generation and SimPoint analysis..."
+echo "[STEP 2] Running trace generation..."
 bash "$RUN_SCRIPT"

--- a/traces/docker_stf_trace_gen/build_docker.sh
+++ b/traces/docker_stf_trace_gen/build_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME="spike-stf"
+docker build -t "$IMAGE_NAME" .

--- a/traces/docker_stf_trace_gen/run_in_docker.sh
+++ b/traces/docker_stf_trace_gen/run_in_docker.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+IMAGE_NAME="spike-stf"
+OUTPUT_DIR="$(pwd)/trace_output"
+
+mkdir -p "$OUTPUT_DIR"
+
+docker run --rm \
+  -v "$OUTPUT_DIR":/output \
+  "$IMAGE_NAME" \
+  bash -c "
+    echo '<REPLACE THIS ECHO COMMAND WITH SPIKE STF TRACE GENERATION COMMAND>' >> /output/EXAMPLE.zstf
+  "


### PR DESCRIPTION
This PR introduces a new folder, docker_stf_trace_gen, as part of the ongoing Workload Analysis Flow mentorship. It includes:
* A Dockerfile that builds a container with the RISC-V GNU toolchain, pk, and Spike-STF.
* Supporting scripts for building and running the Docker image
* Documentation Readme

The current workflow does not yet include the commands to produce STF files. These will be added in a future PR. For now it only includes the basis for the documentation and the Dockerfile with the necessary tools.