### PR TITLE
trace generator tool

### DIFF
--- a/traces/docker_stf_trace_gen/Dockerfile
+++ b/traces/docker_stf_trace_gen/Dockerfile
@@ -1,16 +1,17 @@
 FROM ubuntu:24.04
 
 # Set environment variables early
-ENV RISCV=/riscv \
-    QEMU_PLUGINS=/qemu/build/contrib/plugins \
-    PATH=$RISCV/bin:/opt/riscv/riscv32-elf/bin:/opt/riscv/riscv64-elf/bin:/opt/riscv/riscv32-glibc/bin:/SimPoint/bin:/qemu/build:$PATH \ 
-    DEBIAN_FRONTEND=noninteractive \
-    WORKDIR=/workspace \
-    WORKLOADS=/workloads \
-    OUTPUT=/output
+ENV RISCV=/riscv
+ENV QEMU_DIR=/qemu
+ENV QEMU_PLUGINS=/qemu/build/contrib/plugins
+ENV PATH=$RISCV/bin:/opt/riscv/riscv32-elf/bin:/opt/riscv/riscv64-elf/bin:/opt/riscv/riscv32-glibc/bin:/SimPoint/bin:/qemu/build:$PATH 
+ENV DEBIAN_FRONTEND=noninteractive
+ENV WORKDIR=/workspace
+ENV WORKLOADS=/workloads
+ENV OUTPUT=/output
 
 # Install dependencies and clean up in one layer
-RUN apt-get update && apt-get install -y \
+RUN apt update && apt install -y \
     autoconf \
     automake \
     autotools-dev \
@@ -53,8 +54,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     zlib1g-dev \
     zstd \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get clean
+    python3-yaml
 
 # Configure git for building
 RUN git config --global url."https://github.com/".insteadOf "git@github.com:" && \
@@ -62,13 +62,14 @@ RUN git config --global url."https://github.com/".insteadOf "git@github.com:" &&
     git config --global user.name "Docker Builder"
 
 # Create directory structure
-RUN mkdir -p /workloads /output /workspace $RISCV
+RUN mkdir -p /output
 
 # Clone repositories in RISCV directory
 WORKDIR $RISCV
-RUN git clone https://github.com/condorcomputing/condor.riscv-isa-sim.git --recurse-submodules && \
-    git clone https://github.com/sparcians/stf_tools && \
-    git clone https://github.com/riscv-software-src/riscv-pk.git
+RUN git clone https://github.com/condorcomputing/condor.riscv-isa-sim.git --recurse-submodules
+RUN git clone https://github.com/sparcians/stf_tools
+RUN git clone https://github.com/riscv-software-src/riscv-pk.git
+RUN git clone https://gitlab.com/ribeiro.v.silva/trace-gen.git
 
 # Clone QEMU and SimPoint
 WORKDIR /
@@ -87,15 +88,14 @@ RUN chmod +x $RISCV/get-tool.sh && \
     echo "Toolchain version:" && \
     riscv64-unknown-linux-gnu-gcc --version 2>/dev/null || echo "Toolchain setup pending"
 
-RUN mkdir -p /qemu/build
 # Build QEMU with plugins support
 WORKDIR /qemu/build
 RUN ../configure \
-        --target-list=riscv32-linux-user,riscv64-linux-user,riscv32-softmmu,riscv64-softmmu \
-        --enable-plugins \
-        --disable-docs \
-        --disable-gtk \
-        --disable-sdl 
+    --target-list=riscv32-linux-user,riscv64-linux-user,riscv32-softmmu,riscv64-softmmu \
+    --enable-plugins \
+    --disable-docs \
+    --disable-gtk \
+    --disable-sdl 
 RUN make -j$(nproc)
 RUN make install
 
@@ -116,6 +116,7 @@ RUN ../configure --prefix=$RISCV/condor.riscv-isa-sim/install
 RUN make -j$(nproc) 
 RUN make regress 
 RUN make install
+ENV STF_DIR=$RISCV/condor.riscv-isa-sim/stf_lib
 
 # Create mount points for runtime mounting
 # Environment and flow scripts will be mounted at runtime
@@ -127,9 +128,18 @@ RUN mkdir -p /workloads/environment /flow /outputs
 # - Host outputs -> /outputs
 
 RUN cp $RISCV/condor.riscv-isa-sim/install/bin/spike /usr/bin/
+
+WORKDIR $RISCV/trace-gen
+RUN make 
+RUN make install
+
+WORKDIR $RISCV/riscv-pk/build
+RUN mkdir $RISCV/pk
+RUN ../configure --prefix=$RISCV/pk --host=riscv64-unknown-elf
+RUN make -j$(nproc)
+RUN make install
+ENV PATH=$RISCV/pk:$PATH 
+
 WORKDIR /workspace 
 
-
 CMD ["/bin/bash"]
-
-# need to mount Volumes and show it in the documenation when runnignthis 

--- a/traces/docker_stf_trace_gen/README.md
+++ b/traces/docker_stf_trace_gen/README.md
@@ -298,12 +298,9 @@ QEMU advantage: 2.70x faster
 More in [doc/emulator-comparison](doc/emulator-comparison)
 
 
-### Trace Generation
-**Important**: QEMU and Spike use different trace formats:
-- **Spike**: Detailed STF (System Trace Format) traces for comprehensive analysis
-- **QEMU**: Simple assembly traces using `-d in_asm` output
+### STF Trace Generation
 
-QEMU cannot generate STF traces, making it useful for running large files and basic traces, while Spike provides detailed tracing capabilities.
+Read the [generate trace](generate_trace.md) file for details.
 
 ## Documentation
 

--- a/traces/docker_stf_trace_gen/converters/base.py
+++ b/traces/docker_stf_trace_gen/converters/base.py
@@ -1,0 +1,8 @@
+from abc import ABC
+from typing import Any
+
+
+class BaseConverter(ABC):
+    @staticmethod
+    def convert(self, input: Any) -> Any:
+        raise NotImplementedError("This method should be overridden by subclasses.")

--- a/traces/docker_stf_trace_gen/converters/host_to_docker_path.py
+++ b/traces/docker_stf_trace_gen/converters/host_to_docker_path.py
@@ -1,0 +1,11 @@
+import os
+from converters.base import BaseConverter
+from data.consts import Const
+
+
+class HostToDockerPathConverter(BaseConverter):
+    @staticmethod
+    def convert(path: str) -> str:
+        parts = os.path.abspath(path).strip(os.sep).split(os.sep)
+        parts.insert(0, Const.DOCKER_TEMP_FOLDER)
+        return os.path.join(*parts)

--- a/traces/docker_stf_trace_gen/data/consts.py
+++ b/traces/docker_stf_trace_gen/data/consts.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Const():
+    DOCKER_IMAGE_NAME = "riscv-perf-model:latest"
+    DOCKER_TEMP_FOLDER = "/host"
+    LIBSTFMEM = "/usr/lib/libstfmem.so"
+    STF_TOOLS = "/riscv/stf_tools/release/tools"
+    SPKIE_PK = "/riscv/riscv-pk/build/pk"

--- a/traces/docker_stf_trace_gen/data/metadata.py
+++ b/traces/docker_stf_trace_gen/data/metadata.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Literal, Optional, Dict, Union
+
+
+@dataclass
+class Author:
+    email: str
+    name: Optional[str] = None
+    company: Optional[str] = None
+
+
+@dataclass
+class Workload:
+    filename: str
+    SHA256: str
+    execution_command: Optional[str]
+    elf_sections: Dict[str, str]
+
+
+@dataclass
+class IpModeInterval:
+    ip: int
+    ip_count: int
+    interval_lenght: int
+
+
+@dataclass
+class InstructionCountModeInterval:
+    start_instruction: int
+    interval_lenght: int
+
+
+@dataclass
+class Stf:
+    timestamp: str
+    stf_trace_info: Dict[str, str]
+    interval_mode: Literal["ip", "instructionCount", "macro", "fullyTrace"]
+    interval: Optional[Union[IpModeInterval, InstructionCountModeInterval]] = None
+
+
+@dataclass
+class Metadata:
+    author: Author
+    workload: Workload
+    stf: Stf
+    description: Optional[str] = None

--- a/traces/docker_stf_trace_gen/factories/metadata_factory.py
+++ b/traces/docker_stf_trace_gen/factories/metadata_factory.py
@@ -1,0 +1,107 @@
+import datetime
+import os
+import re
+from typing import Dict, Literal, Optional
+from elftools.elf.elffile import ELFFile
+from utils.util import Util
+from utils.docker_orchestrator import DockerOrchestrator
+from data.metadata import Author, InstructionCountModeInterval, IpModeInterval, Metadata, Stf, Workload
+
+
+class MetadataFactory():
+    def __init__(self, docker: DockerOrchestrator):
+        self.docker = docker
+
+    def create(
+        self,
+        workload_path: str,
+        trace_path: str,
+        trace_interval_mode: Literal["ip", "instructionCount", "macro", "fullyTrace"],
+        start_instruction: Optional[int] = None,
+        num_instructions: Optional[int] = None,
+        start_pc: Optional[int] = None,
+        pc_threshold: Optional[int] = None,
+        execution_command: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> Metadata:
+        author = Author(name="John Doe", company="Example Corp", email="john.doe@example.com")
+        workload = self._create_workload(workload_path, execution_command)
+        stf = self._create_stf(
+            trace_path,
+            trace_interval_mode,
+            start_instruction,
+            num_instructions,
+            start_pc,
+            pc_threshold)
+
+        return Metadata(description=description, author=author, workload=workload, stf=stf)
+
+    def _create_workload(self, workload_path: str, execution_command: Optional[str] = None) -> Workload:
+        sha256 = Util.compute_sha256(workload_path)
+        elf_sections = self._get_workload_sections(workload_path)
+        filename = os.path.basename(workload_path)
+        return Workload(filename, sha256, execution_command, elf_sections)
+
+    def _create_stf(
+        self,
+        trace_path: str,
+        interval_mode: Literal["ip", "instructionCount", "macro", "fullyTrace"],
+        start_instruction: Optional[int] = None,
+        num_instructions: Optional[int] = None,
+        start_pc: Optional[int] = None,
+        pc_threshold: Optional[int] = None,
+    ) -> Stf:
+        interval = None
+        if interval_mode == "ip":
+            interval = IpModeInterval(ip=start_pc, ip_count=pc_threshold, interval_lenght=num_instructions)
+        elif interval_mode == "instructionCount":
+            interval = InstructionCountModeInterval(start_instruction, num_instructions)
+
+        utc_datetime = datetime.datetime.now(datetime.timezone.utc)
+        utc_timestamp = utc_datetime.timestamp()
+
+        stf_trace_info = self._get_stf_info(trace_path)
+        return Stf(utc_timestamp, stf_trace_info, interval_mode, interval)
+
+    def _get_workload_sections(self, workload_path: str) -> dict[str, str]:
+        sections = ['.comment', '.riscv.attributes', '.GCC.command.line']
+        result = {}
+
+        if not os.path.exists(workload_path):
+            raise FileNotFoundError(f"Workload file not found: {workload_path}")
+
+        with open(workload_path, 'rb') as binary_file:
+            elf = ELFFile(binary_file)
+            for section in sections:
+                section_data = elf.get_section_by_name(section)
+                if section_data:
+                    strings = re.findall(rb'[\x20-\x7E]{2,}', section_data.data())
+                    decoded = ' '.join(s.decode('utf-8') for s in strings)
+                    decoded = decoded.replace('\'', '')
+                    result[section.lstrip('.')] = decoded
+
+        return result
+
+    def _get_stf_info(self, trace_path: str) -> Dict[str, str]:
+        trace_info = self.docker.run_stf_tool("stf_trace_info", trace_path).decode('utf-8')
+
+        metadata = {}
+        values_section = []
+        trace_info_lines = trace_info.strip().split('\n')
+
+        in_values = False
+        for line in trace_info_lines:
+            line = line.strip()
+            if len(line.strip()) == 0:
+                in_values = True
+                continue
+
+            if not in_values:
+                if ' ' in line:
+                    key, value = line.strip().split(None, 1)
+                    metadata[key.strip()] = value.strip()
+            else:
+                values_section.append(line.strip())
+
+        metadata['STF_FEATURES'] = values_section
+        return metadata

--- a/traces/docker_stf_trace_gen/generate_trace.md
+++ b/traces/docker_stf_trace_gen/generate_trace.md
@@ -1,0 +1,166 @@
+# Trace Generation Tool
+
+This tool generates execution traces for RISC-V workloads using either **Spike** or **QEMU** emulators.  
+
+There are **three different modes** for generating traces:
+- **Macro** → uses `START_TRACE` and `STOP_TRACE` macros embedded in the workload  
+- **Instruction Count (`insn_count`)** → traces a fixed number of instructions after skipping some  
+- **Program Counter (`pc_count`)** → traces after a specific program counter (PC) is reached  
+
+---
+
+## Table of Contents
+
+1. [Quickstart](#quickstart)
+2. [Usage](#usage)
+3. [Global Options](#global-options)
+4. [Modes](#modes)  
+   - [Macro](#macro)  
+   - [Instruction Count](#insn_count)  
+   - [Program Counter](#pc_count)  
+5. [Mode Restrictions](#mode-restrictions)
+6. [Summary Table](#summary-table)
+7. [Help and More Info](#help-and-more-info)
+
+---
+
+## Quickstart
+
+1. **Macro mode with Spike**  
+   Trace using `START_TRACE` / `STOP_TRACE` markers inside the workload:  
+    ```bash
+   python generate_trace.py --emulator spike macro workload.elf
+    ```
+
+2. **Instruction Count mode**
+   Skip 1000 instructions, then trace 5000 instructions:
+
+   ```bash
+   python generate_trace.py --emulator qemu insn_count \
+       --num-instructions 5000 --start-instruction 1000 workload.elf
+   ```
+
+3. **Program Counter mode (QEMU only)**
+   Start tracing after PC `0x80000000` is hit 5 times, trace 2000 instructions:
+
+   ```bash
+   python generate_trace.py --emulator qemu pc_count \
+       --num-instructions 2000 --start-pc 0x80000000 --pc-threshold 5 workload.elf
+   ```
+
+---
+
+## Usage
+
+```bash
+python generate_trace.py [OPTIONS] MODE WORKLOAD_PATH
+```
+
+Example with help:
+
+```bash
+python generate_trace.py macro --help
+```
+
+---
+
+## Global Options
+
+These options apply to all modes:
+
+* **`--emulator {spike,qemu}`** *(required)*
+  Select which emulator to use.
+
+* **`--isa ISA`** *(optional)*
+  Instruction set architecture (e.g., `rv64imafdc`).
+
+* **`--dump`** *(flag)*
+  Create a trace file dump.
+
+* **`--pk`** *(flag)*
+  Run Spike with **pk (proxy kernel)**.
+
+* **`--image-name IMAGE_NAME`** *(default: `Const.DOCKER_IMAGE_NAME`)*
+  Use a custom Docker image instead of the default.
+
+* **`-o, --output OUTPUT`** *(optional)*
+  Output folder or file path.
+
+* **`workload`** *(positional, required)*
+  Path to workload binary.
+
+---
+
+## Modes
+
+### `macro`
+
+Trace mode using `START_TRACE` and `STOP_TRACE` macros in the workload binary.
+
+* **Only works with Spike**
+* No additional arguments required beyond the workload path.
+
+**Example:**
+
+```bash
+python generate_trace.py --emulator spike macro workload.elf
+```
+
+---
+
+### `insn_count`
+
+Trace a fixed number of instructions after skipping a given number.
+
+**Arguments:**
+
+* **`--num-instructions`** *(required, int)* → number of instructions to trace.
+* **`--start-instruction`** *(required, int, default=0)* → instructions to skip before tracing starts.
+
+**Example:**
+
+```bash
+python generate_trace.py --emulator qemu insn_count \
+    --num-instructions 5000 --start-instruction 1000 workload.elf
+```
+
+---
+
+### `pc_count`
+
+Trace a fixed number of instructions after reaching a given PC value a certain number of times.
+
+* **Only works with QEMU**
+
+**Arguments:**
+
+* **`--num-instructions`** *(required, int)* → number of instructions to trace.
+* **`--start-pc`** *(required, int)* → starting program counter (hex or decimal).
+* **`--pc-threshold`** *(required, int, default=1)* → number of times the PC must be hit before tracing begins.
+
+**Example:**
+
+```bash
+python generate_trace.py --emulator qemu pc_count \
+    --num-instructions 2000 --start-pc 0x80000000 --pc-threshold 5 workload.elf
+```
+
+---
+
+## Mode Restrictions
+
+* `macro` mode **cannot** be used with `qemu`.
+* `pc_count` mode **cannot** be used with `spike`.
+* Each mode has its own required arguments.
+
+---
+
+## Summary Table
+
+| Mode         | Emulator   | Required Arguments                                   |
+| ------------ | ---------- | ---------------------------------------------------- |
+| `macro`      | spike      | workload                                             |
+| `insn_count` | spike/qemu | `--num-instructions`, `--start-instruction`          |
+| `pc_count`   | qemu       | `--num-instructions`, `--start-pc`, `--pc-threshold` |
+
+---

--- a/traces/docker_stf_trace_gen/generate_trace.py
+++ b/traces/docker_stf_trace_gen/generate_trace.py
@@ -1,0 +1,115 @@
+import argparse
+from dataclasses import asdict
+import os
+import yaml
+from factories.metadata_factory import MetadataFactory
+from data.metadata import Metadata
+from utils.trace_generator_arg_parser import parse_args
+from utils.docker_orchestrator import DockerOrchestrator
+from data.consts import Const
+from converters.host_to_docker_path import HostToDockerPathConverter
+
+
+class TraceGenerator():
+    def __init__(self, docker: DockerOrchestrator):
+        self.docker = docker
+        self.metadataFactory = MetadataFactory(docker)
+
+    def run(self, args: argparse.Namespace) -> None:
+        args.output = self._get_ouput_path(args)
+        docker_paths = self._convert_paths(args)
+
+        self._run_trace(args, docker_paths)
+        metadata = self._generate_metadata(args)
+        self._save_metadata(args.output, metadata)
+
+        if args.dump:
+            dump_path = f"{args.output}.dump"
+            self.docker.run_stf_tool("stf_dump", args.output, dump_path)
+
+    def _get_ouput_path(self, args: argparse.Namespace) -> str:
+        if not args.output:
+            return f"{args.workload}.zstf"
+
+        isDir = not (os.path.splitext(args.ouput)[1])
+        if not isDir and not args.output.endswith("zstf"):
+            raise ValueError("Invalid output file extension. Expected .zstf or directory.")
+
+        if not isDir:
+            return args.output
+
+        workload_filename = os.path.basename(args.workload)
+        return os.path.join(args.output, workload_filename)
+
+    def _convert_paths(
+        self,
+        args: argparse.Namespace,
+        path_arguments: list[str] = ['workload', 'output']
+    ) -> dict[str, str]:
+        docker_paths = {}
+        for path_argument in path_arguments:
+            arg_value = getattr(args, path_argument)
+            if arg_value:
+                docker_paths[arg_value] = HostToDockerPathConverter.convert(arg_value)
+
+        return docker_paths
+
+    def _run_trace(self, args: argparse.Namespace, docker_paths: dict[str, str]):
+        bash_cmd = ""
+        if args.emulator == "spike":
+            bash_cmd = self._get_spike_command(args, docker_paths)
+        elif args.emulator == "qemu":
+            bash_cmd = self._get_qemu_command(args, docker_paths)
+        else:
+            raise ValueError(f"Invalid emulator ({args.emulator}) provided")
+
+        self.docker.run_command(bash_cmd, docker_paths)
+
+    def _get_spike_command(self, args: argparse.Namespace, docker_paths: dict[str, str]) -> str:
+        isa = f"--isa={args.isa}" if args.isa else ""
+        pk = f"{Const.SPKIE_PK}" if args.pk else ""
+
+        if args.mode == "insn_count":
+            return f"spike {isa} --stf_trace {docker_paths[args.output]} --stf_trace_memory_records --stf_insn_num_tracing --stf_insn_start {str(args.start_instruction)} --stf_insn_count {str(args.num_instructions)}  {pk} {docker_paths[args.workload]}"
+        elif args.mode == "macro":
+            return f"spike {isa} --stf_trace {docker_paths[args.output]} --stf_trace_memory_records --stf_macro_tracing {pk} {docker_paths[args.workload]}"
+
+        raise NotImplementedError(f"mode {args.mode} invalid for spike")
+
+    def _get_qemu_command(self, args: argparse.Namespace, docker_paths: dict[str, str]) -> str:
+        args.start_instruction += 1
+        if args.mode == "insn_count":
+            return f"qemu-riscv64 -plugin {Const.LIBSTFMEM},mode=dyn_insn_count,start_dyn_insn={args.start_instruction},num_instructions={args.num_instructions},outfile={docker_paths[args.output]} -d plugin -- {docker_paths[args.workload]}"
+        elif args.mode == "pc_count":
+            return f"qemu-riscv64 -plugin {Const.LIBSTFMEM},mode=ip,start_ip={args.start_pc},ip_hit_threshold={args.pc_threshold},num_instructions={args.num_instructions},outfile={docker_paths[args.output]} -d plugin -- {docker_paths[args.workload]}"
+
+        raise NotImplementedError(f"mode {args.mode} invalid for qemu")
+
+    def _generate_metadata(self, args: argparse.Namespace) -> Metadata:
+        workload_path = args.workload
+        return self.metadataFactory.create(
+            workload_path=workload_path,
+            trace_path=args.output,
+            trace_interval_mode=args.mode,
+            start_instruction=getattr(args, "start_instruction", None),
+            num_instructions=getattr(args, "num_instructions", None),
+            start_pc=getattr(args, "start_pc", None),
+            pc_threshold=getattr(args, "pc_threshold", None),
+            execution_command=None,
+            description=None,
+        )
+
+    def _save_metadata(self, trace_path: str, metadata: Metadata):
+        metadata_path = f"{trace_path}.metadata.yaml"
+        with open(metadata_path, 'w') as file:
+            yaml.dump(asdict(metadata), file)
+
+
+def main():
+    args = parse_args()
+    docker = DockerOrchestrator(args)
+    TraceGenerator(docker).run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/traces/docker_stf_trace_gen/utils/config.py
+++ b/traces/docker_stf_trace_gen/utils/config.py
@@ -3,7 +3,7 @@
 import yaml
 import shlex
 from pathlib import Path
-from utils.util import log
+from utils.util import Util
 
 class BoardConfig:
     """Board configuration parser with support for tagged sections"""
@@ -17,7 +17,7 @@ class BoardConfig:
     def load_config(self):
         """Load configuration from board-specific file"""
         if not self.config_file.exists():
-            log("ERROR", f"Board config not found: {self.config_file}")
+            Util.log("ERROR", f"Board config not found: {self.config_file}")
             return
         
         with open(self.config_file, 'r') as f:
@@ -43,7 +43,7 @@ class BoardConfig:
                 return shlex.split(value)
             except ValueError as e:
                 # Fallback to simple split if shlex fails (e.g., unmatched quotes)
-                log("WARNING", f"Failed to parse config value '{value}' with shlex: {e}")
+                Util.log("WARNING", f"Failed to parse config value '{value}' with shlex: {e}")
                 return value.split()
         
         return []

--- a/traces/docker_stf_trace_gen/utils/docker_orchestrator.py
+++ b/traces/docker_stf_trace_gen/utils/docker_orchestrator.py
@@ -1,0 +1,67 @@
+
+import argparse
+import os
+import docker
+from typing import Optional
+from data.consts import Const
+
+
+class DockerOrchestrator():
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.docker_image_name = args.image_name if args.image_name else Const.DOCKER_IMAGE_NAME
+        self.docker_client = docker.from_env()
+
+    def run_command(self, command: str, binds: Optional[dict[str, str]]) -> str:
+        volumes = {}
+        for host_path, docker_path in binds.items():
+            host_folder = os.path.dirname(host_path)
+            docker_folder = os.path.dirname(docker_path)
+            volumes[host_folder] = {"bind": docker_folder, "mode": "rw"}
+
+        print(command)
+        container = None
+        try:
+            container = self.docker_client.containers.run(
+                image=self.docker_image_name,
+                command=["bash", "-c", command],
+                volumes=volumes,
+                detach=True,
+                stdout=True,
+                stderr=True
+            )
+
+            exit_code = container.wait()["StatusCode"]
+            stdout_logs = container.logs(stdout=True, stderr=False)
+            stderr_logs = container.logs(stdout=False, stderr=True)
+
+            if exit_code != 0:
+                print("Exit code:", exit_code)
+                print("STDOUT:\n", stdout_logs.decode())
+                print("STDERR:\n", stderr_logs.decode())
+
+        finally:
+            try:
+                container.remove(force=True)
+            except Exception as e:
+                print("Cleanup failed:", e)
+            return stdout_logs
+
+    def run_stf_tool(self, tool: str, host_input: str, host_output: Optional[str] = None):
+        docker_input = self.convert_host_path_to_docker_path(host_input)
+        binds = {
+            host_input: docker_input,
+        }
+
+        tool_path = os.path.join(Const.STF_TOOLS, tool, tool)
+        cmd = f"{tool_path} {docker_input}"
+        result = self.run_command(cmd, binds)
+        if host_output is not None:
+            with open(host_output, "wb") as f:
+                f.write(result)
+
+        return result
+
+    def convert_host_path_to_docker_path(self, path: str) -> str:
+        parts = os.path.abspath(path).strip(os.sep).split(os.sep)
+        parts.insert(0, Const.DOCKER_TEMP_FOLDER)
+        return os.path.join(*parts)

--- a/traces/docker_stf_trace_gen/utils/trace_generator_arg_parser.py
+++ b/traces/docker_stf_trace_gen/utils/trace_generator_arg_parser.py
@@ -1,0 +1,72 @@
+import argparse
+import sys
+from data.consts import Const
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate traces for a workload",
+        usage='python generate_trace.py [OPTIONS] WORKLOAD_PATH'
+    )
+    parser.add_argument("--emulator", required=True, choices=["spike", "qemu"])
+    parser.add_argument("--isa", required=False, help="Instruction set architecture")
+    parser.add_argument("--dump", action='store_true', required=False, default=False, help="Create trace file dump")
+    parser.add_argument("--pk", action='store_true', required=False, default=False, help="Use Spike pk (proxy kernel)")
+    parser.add_argument(
+        "--image-name",
+        required=False,
+        default=Const.DOCKER_IMAGE_NAME,
+        help=f"Custom docker image name. default: {Const.DOCKER_IMAGE_NAME}")
+    parser.add_argument('-o', '--output', required=False, help='Output folder or file path')
+
+    subparsers = parser.add_subparsers(title='Mode', dest='mode')
+    subparsers.add_parser(
+        'macro',
+        help='Trace mode using START_TRACE and STOP_TRACE macros on the workload binary',
+        description='Trace mode using START_TRACE and STOP_TRACE macros on the workload binary',
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    inst_count_mode_parser = subparsers.add_parser(
+        'insn_count',
+        help='Traces a fixed number of instructions, after a given start instruction index',
+        description='Traces a fixed number of instructions, after a given start instruction index',
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    inst_count_mode_parser.add_argument(
+        "--num-instructions",
+        required=True,
+        type=int,
+        help="Number of instructions to trace")
+    inst_count_mode_parser.add_argument(
+        "--start-instruction",
+        required=True,
+        type=int,
+        default=0,
+        help="Number of instructions to skip before tracing (insn_count mode)")
+
+    pc_mode_parser = subparsers.add_parser(
+        'pc_count',
+        help='Traces a fixed number of instructions, after a given PC value and PC hits count',
+        description='Traces a fixed number of instructions, after a given PC value and PC hits count',
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    pc_mode_parser.add_argument("--num-instructions", required=True, type=int, help="Number of instructions to trace")
+    pc_mode_parser.add_argument("--start-pc", required=True, type=int, help="Starting program counter (pc_count mode)")
+    pc_mode_parser.add_argument(
+        "--pc-threshold",
+        required=True,
+        type=int,
+        default=1,
+        help="PC hit threshold (pc_count mode)")
+
+    parser.add_argument("workload", help="Path to workload file")
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        print("\nRun 'trace_share COMMAND --help' for more information on a command.")
+        print("\nFor more help on how to use trace_share, head to GITHUB_README_LINK")
+        sys.exit(0)
+
+    args = parser.parse_args()
+    return args

--- a/traces/docker_stf_trace_gen/utils/util.py
+++ b/traces/docker_stf_trace_gen/utils/util.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 import subprocess
 import time
@@ -7,6 +8,7 @@ import shutil
 import logging
 from enum import Enum
 
+
 class LogLevel(Enum):
     INFO = "\033[32m"
     ERROR = "\033[31m"
@@ -14,64 +16,87 @@ class LogLevel(Enum):
     DEBUG = "\033[34m"
     HEADER = "\033[95m\033[1m"
 
+
 logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s: %(message)s", datefmt="%H:%M:%S")
 
-def log(level: LogLevel, msg: str, file=sys.stdout):
-    """Log with ANSI color and timestamp; raises on ERROR."""
-    color = level.value
-    print(f"{color}{msg}\033[0m", file=file if level != LogLevel.ERROR else sys.stderr)
-    if level == LogLevel.ERROR:
-        exit(1)
-        raise RuntimeError(msg) # do we want to raise here? 
 
-    
+class Util():
+    @staticmethod
+    def compute_sha256(file_path: str) -> str:
+        hash_sha256 = hashlib.sha256()
+        with open(file_path, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                hash_sha256.update(chunk)
+        return hash_sha256.hexdigest()
 
-def run_cmd(cmd: List[str], cwd: Optional[Path] = None, timeout: int = 300, show: bool = True) -> Tuple[bool, str, str]:
-    """Run command, return (success, stdout, stderr)."""
-    if show:
-        log(LogLevel.DEBUG, f"Running: {' '.join(map(str, cmd))}")
-    try:
-        result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout, check=False)
-        if not result.returncode == 0:
-            log(LogLevel.ERROR, f"Command failed: {result.stderr}")
-        return result.returncode == 0, result.stdout, result.stderr
-    except subprocess.TimeoutExpired:
-        log(LogLevel.ERROR, f"Timeout after {timeout}s")
-    except Exception as e:
-        log(LogLevel.ERROR, f"Exception: {e}")
+    @staticmethod
+    def log(level: LogLevel, msg: str, file=sys.stdout):
+        """Log with ANSI color and timestamp; raises on ERROR."""
+        color = level.value
+        print(f"{color}{msg}\033[0m", file=file if level != LogLevel.ERROR else sys.stderr)
+        if level == LogLevel.ERROR:
+            exit(1)
+            raise RuntimeError(msg)  # do we want to raise here?
 
-def get_time() -> float:
-    """Return current time in seconds."""
-    return time.time()
+    @staticmethod
+    def run_cmd(
+        cmd: List[str],
+        cwd: Optional[Path] = None,
+        timeout: int = 300,
+        show: bool = True
+    ) -> Tuple[bool, str, str]:
+        """Run command, return (success, stdout, stderr)."""
+        if show:
+            Util.log(LogLevel.DEBUG, f"Running: {' '.join(map(str, cmd))}")
+        try:
+            result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout, check=False)
+            if not result.returncode == 0:
+                Util.log(LogLevel.ERROR, f"Command failed: {result.stderr}")
+            return result.returncode == 0, result.stdout, result.stderr
+        except subprocess.TimeoutExpired:
+            Util.log(LogLevel.ERROR, f"Timeout after {timeout}s")
+        except Exception as e:
+            Util.log(LogLevel.ERROR, f"Exception: {e}")
 
-def ensure_dir(path: Path) -> Path:
-    """Create directory if it doesn't exist."""
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    @staticmethod
+    def get_time() -> float:
+        """Return current time in seconds."""
+        return time.time()
 
-def clean_dir(path: Path) -> Path:
-    """Clean and recreate directory."""
-    if path.exists():
-        shutil.rmtree(path)
-    return ensure_dir(path)
+    @staticmethod
+    def ensure_dir(path: Path) -> Path:
+        """Create directory if it doesn't exist."""
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
-def validate_tool(tool: str):
-    """Check if tool is in PATH."""
-    if not shutil.which(tool):
-        log(LogLevel.ERROR, f"Tool not found: {tool}")
-        return False
-    return True
+    @staticmethod
+    def clean_dir(path: Path) -> Path:
+        """Clean and recreate directory."""
+        if path.exists():
+            shutil.rmtree(path)
+        return Util.ensure_dir(path)
 
-def file_exists(path: Path | str) -> bool:
-    """Check if file exists."""
-    return Path(path).exists()
+    @staticmethod
+    def validate_tool(tool: str):
+        """Check if tool is in PATH."""
+        if not shutil.which(tool):
+            Util.log(LogLevel.ERROR, f"Tool not found: {tool}")
+            return False
+        return True
 
-def read_file_lines(path: Path) -> List[str]:
-    """Read non-empty lines from file."""
-    if not file_exists(path):
-        log(LogLevel.ERROR, f"File not found: {path}")
-    return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+    @staticmethod
+    def file_exists(path: Path | str) -> bool:
+        """Check if file exists."""
+        return Path(path).exists()
 
-def write_file_lines(path: Path, lines: List[str]):
-    """Write lines to file."""
-    path.write_text("\n".join(lines) + "\n")
+    @staticmethod
+    def read_file_lines(path: Path) -> List[str]:
+        """Read non-empty lines from file."""
+        if not Util.file_exists(path):
+            Util.log(LogLevel.ERROR, f"File not found: {path}")
+        return [line.strip() for line in path.read_text().splitlines() if line.strip()]
+
+    @staticmethod
+    def write_file_lines(path: Path, lines: List[str]):
+        """Write lines to file."""
+        path.write_text("\n".join(lines) + "\n")

--- a/traces/stf_metadata/README.md
+++ b/traces/stf_metadata/README.md
@@ -1,7 +1,5 @@
 # STF (Simulation Trace Format) Metadata Specification
 
-> This specification is still under development.
-
 ## Table of Contents
 
 1. [Introduction](#introduction)
@@ -47,6 +45,7 @@ stf:
     GEN_VERSION: "Trace generator version"
     GEN_COMMENT: "Trace generator comment (e.g., git commit SHA for spike-stf)"
     STF_FEATURES: "list of STF features in the STF file"
+  interval_mode: "Tracing Strategy. (Fully traced, Macro defined start and stop, Instructions count, Program counter count)"
   trace_interval:
     instruction_pc: "Program counter (PC) value at the start of the trace"
     pc_count: "Program counter execution count value present at the start of the trace"
@@ -91,10 +90,8 @@ stf:
       - STF_CONTAIN_PHYSICAL_ADDRESS
       - STF_CONTAIN_RV64
       - STF_CONTAIN_EVENT64
+  interval_mode: inst_count
   trace_interval:
-    instruction_pc: 0
-    pc_count: 0
-    interval_length: 100
     start_instruction_index: 0
     end_instruction_index: 100
 ```


### PR DESCRIPTION
This PR introduces the Trace Generator Tool along with improvements in the documentation at traces/stf_trace_archive/README.md and traces/docker_stf_trace_gen/README.md. The main goal of this tool is to create STF trace and it's metadata file for workload using docker.

The trace generator tool comes with three different modes
- **Macro** → uses `START_TRACE` and `STOP_TRACE` macros embedded in the workload  
- **Instruction Count (`insn_count`)** → traces a fixed number of instructions after skipping some  
- **Program Counter (`pc_count`)** → traces after a specific program counter (PC) is reached  

Other options included in the tool are:
* **`--isa ISA`**. Instruction set architecture (e.g., `rv64imafdc`).
* **`--dump`**. Create a trace file dump.
* **`--pk`**. Run Spike with **pk (proxy kernel)**.


This PR files follows this structure:
```text
README.md                  # Main documentation file
README.md                  # Trace generator documentation file
src/
├── data/                  # Core data models and classes
├── converters/                  # Converter classes
├── factories/              # Factory classes
├── utils/                 # Utility functions and helpers
└── generate_trace.py       # Main CLI entry point
```

### Quickstart

1. **Macro mode  (SPIKE only)**  
   Trace using `START_TRACE` / `STOP_TRACE` markers inside the workload:  
    ```bash
   python generate_trace.py --emulator spike macro workload.elf
    ```

2. **Instruction Count mode**
   Skip 1000 instructions, then trace 5000 instructions:

   ```bash
   python generate_trace.py --emulator qemu insn_count \
       --num-instructions 5000 --start-instruction 1000 workload.elf
   ```

3. **Program Counter mode (QEMU only)**
   Start tracing after PC `0x80000000` is hit 5 times, trace 2000 instructions:

   ```bash
   python generate_trace.py --emulator qemu pc_count \
       --num-instructions 2000 --start-pc 0x80000000 --pc-threshold 5 workload.elf
   ```

### Next Steps:
* Integrate `utils/docker_orchestrator.py` with all docker related function created on PR #275
* Add a simpoint option, passing a simpoint file as input and generating traces from it
* Validate and compare trace results generated by both Spike and QEMU
* Look at including a Macro mode for the qemu plugin
* Create test classes