### PR TITLE
Updated sparta to map_v2.2.3

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: sparcians/map
           path: map
-          ref: map_v2.0.21
+          ref: map_v2.2.3
 
       # Setup build environment
       - name: Grab Python v3.8

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -39,6 +39,7 @@ jobs:
           repository: sparcians/map
           path: map
           ref: map_v2.2.3
+          submodules: recursive
 
       # Setup build environment
       - name: Grab Python v3.8

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -46,6 +46,7 @@ jobs:
           repository: sparcians/map
           path: map
           ref: map_v2.2.3
+          submodules: recursive
 
       # Setup build environment
       - name: Grab Python v3.8

--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           repository: sparcians/map
           path: map
-          ref: map_v2.0.21
+          ref: map_v2.2.3
 
       # Setup build environment
       - name: Grab Python v3.8

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ under development.
    * (flex) flex 2.6.4
    * (bison) bison 3.8.2
 
-1. Confirm that map/sparta branch is `map_v2.0.21`
+1. Confirm that map/sparta branch is `map_v2.2.3`
 
 1. Build Olympia in one of three modes (see below):
    * `release`: Highly optimized, no debug w/ LTO (if supported)

--- a/sim/OlympiaSim.cpp
+++ b/sim/OlympiaSim.cpp
@@ -72,7 +72,7 @@ void OlympiaSim::buildTree_()
     cpu_factory->buildTree(getRoot());
 
     // Set the workload in the simulation configuration
-    auto extension = sparta::notNull(cpu_tn->getExtension("simulation_configuration"));
+    auto extension = sparta::notNull(cpu_tn->createExtension("simulation_configuration"));
     auto workload  = extension->getParameters()->getParameter("workload");
     workload->setValueFromString(workload_);
 


### PR DESCRIPTION
Updated sparta to map_v2.2.3

The only change that happened was with the api for extensions : 

```bash
- auto extensions = sparta::notNull(cpu_tn->getExtension("simulation_configuration"));
+ auto extensions = sparta::notNull(cpu_tn->createExtension("simulation_configuration"));
```

Here is the sparta branch I was on : 

```bash
jha@MAGICIAN:~/workspace/packages/map/sparta$ git branch -a
* (HEAD detached at map_v2.2.3)
  master
  remotes/origin/HEAD -> origin/master
  remotes/origin/benoy-sifive-readme_conda_macos
```

Make regress passes : 

```bash
128/132 Test  #82: olympia_arch_small_core_31_custom_core ......................   Passed   37.24 sec
129/132 Test  #81: olympia_arch_small_core_31_custom_dhry_test .................   Passed   44.13 sec
130/132 Test  #84: olympia_arch_small_core_32_custom_core ......................   Passed   32.46 sec
131/132 Test  #83: olympia_arch_small_core_32_custom_dhry_test .................   Passed   38.84 sec
132/132 Test #132: fusion_test .................................................   Passed  141.61 sec

100% tests passed, 0 tests failed out of 132

Total Test time (real) = 740.96 sec
[100%] Built target regress
```