### PR TITLE
stf_lib update to a96e73f

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
   target_compile_options (mss     PUBLIC -flto)
   target_compile_options (olympia PUBLIC -flto)
   target_link_options    (olympia PUBLIC -flto)
+  target_link_options ( core PUBLIC -flto)
+  target_link_options ( mss PUBLIC -flto)
 endif()
 
 # Create a few links like reports and arch directories

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,6 @@ set (DISABLE_STF_TESTS ON)
 if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
   set (FULL_LTO true)
 endif()
-include(${STF_LIB_BASE}/cmake/stf_linker_setup.cmake)
-setup_stf_linker(false)
-
 # Use ccache if installed
 find_program (CCACHE_PROGRAM ccache)
 if (CCACHE_PROGRAM)
@@ -91,7 +88,7 @@ add_executable(olympia
   sim/OlympiaSim.cpp
   sim/main.cpp
 )
-target_link_libraries (olympia core mss SPARTA::sparta ${STF_LINK_LIBS})
+target_link_libraries (olympia core mss SPARTA::sparta stf)
 
 if (CMAKE_BUILD_TYPE MATCHES "^[Rr]elease")
   target_compile_options (core    PUBLIC -flto)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(
         -DGIT_VERSION_FILE=${GIT_VERSION_FILE}
         -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/GenerateGitVersion.cmake
-    DEPENDS 
+    DEPENDS
         ${CMAKE_SOURCE_DIR}/.git/HEAD
         ${CMAKE_SOURCE_DIR}/.git/index
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -39,7 +39,7 @@ add_library(instgen
 
 find_package(Boost REQUIRED COMPONENTS json)
 
-target_link_libraries(instgen ${STF_LINK_LIBS} mavis Boost::json)
+target_link_libraries(instgen PUBLIC stf  mavis Boost::json)
 
 get_property(SPARTA_INCLUDE_PROP TARGET SPARTA::sparta PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(core SYSTEM PRIVATE ${SPARTA_INCLUDE_PROP})

--- a/test/core/dcache/CMakeLists.txt
+++ b/test/core/dcache/CMakeLists.txt
@@ -2,7 +2,7 @@ project(Dcache_test)
 
 add_executable(Dcache_test Dcache_test.cpp)
 
-target_link_libraries(Dcache_test core common_test mss ${STF_LINK_LIBS} SPARTA::sparta)
+target_link_libraries(Dcache_test core common_test mss stf SPARTA::sparta)
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/test_arches     ${CMAKE_CURRENT_BINARY_DIR}/test_arches SYMBOLIC)

--- a/test/core/dispatch/CMakeLists.txt
+++ b/test/core/dispatch/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(Dispatch_test)
 
 add_executable(Dispatch_test Dispatch_test.cpp)
-target_link_libraries(Dispatch_test core common_test ${STF_LINK_LIBS} mavis SPARTA::sparta)
+target_link_libraries(Dispatch_test core common_test stf mavis SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)

--- a/test/core/issue_queue/CMakeLists.txt
+++ b/test/core/issue_queue/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(IssueQueue_test)
 
 add_executable(IssueQueue_test IssueQueue_test.cpp ${SIM_BASE}/sim/OlympiaSim.cpp)
-target_link_libraries(IssueQueue_test core common_test ${STF_LINK_LIBS} mavis SPARTA::sparta)
+target_link_libraries(IssueQueue_test core common_test stf mavis SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)

--- a/test/core/l2cache/CMakeLists.txt
+++ b/test/core/l2cache/CMakeLists.txt
@@ -2,7 +2,7 @@ project(L2Cache_test)
 
 add_executable(L2Cache_test L2Cache_test.cpp)
 
-target_link_libraries(L2Cache_test core common_test mss ${STF_LINK_LIBS} SPARTA::sparta)
+target_link_libraries(L2Cache_test core common_test mss stf SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)

--- a/test/core/lsu/CMakeLists.txt
+++ b/test/core/lsu/CMakeLists.txt
@@ -4,7 +4,7 @@ target_link_libraries(core mss)
 
 add_executable(Lsu_test Lsu_test.cpp ${SIM_BASE}/sim/OlympiaSim.cpp)
 
-target_link_libraries (Lsu_test core common_test ${STF_LINK_LIBS} SPARTA::sparta)
+target_link_libraries (Lsu_test core common_test stf SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)

--- a/test/core/rename/CMakeLists.txt
+++ b/test/core/rename/CMakeLists.txt
@@ -5,7 +5,7 @@ target_link_libraries (core mss)
 add_executable(Rename_test Rename_test.cpp ${SIM_BASE}/sim/OlympiaSim.cpp)
 #add_executable(Rename_test_full Rename_test_full.cpp ${SIM_BASE}/sim/OlympiaSim.cpp)
 
-target_link_libraries(Rename_test core common_test ${STF_LINK_LIBS} mavis SPARTA::sparta)
+target_link_libraries(Rename_test core common_test stf mavis SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)

--- a/test/core/unit_template/CMakeLists.txt
+++ b/test/core/unit_template/CMakeLists.txt
@@ -21,7 +21,7 @@ project(${PRJ})
 add_executable(${EXE} Testbench.cpp Dut.cpp Src.cpp)
 target_include_directories(${EXE} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(${EXE} core common_test ${STF_LINK_LIBS} mavis SPARTA::sparta)
+target_link_libraries(${EXE} core common_test stf mavis SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json
                  ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)

--- a/test/core/vector/CMakeLists.txt
+++ b/test/core/vector/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(Vector_test)
 
 add_executable(Vector_test Vector_test.cpp ${SIM_BASE}/sim/OlympiaSim.cpp)
-target_link_libraries(Vector_test core common_test ${STF_LINK_LIBS} mavis SPARTA::sparta)
+target_link_libraries(Vector_test core common_test stf mavis SPARTA::sparta)
 
 file(CREATE_LINK ${SIM_BASE}/mavis/json ${CMAKE_CURRENT_BINARY_DIR}/mavis_isa_files SYMBOLIC)
 file(CREATE_LINK ${SIM_BASE}/arches     ${CMAKE_CURRENT_BINARY_DIR}/arches          SYMBOLIC)


### PR DESCRIPTION
Closes #304 

Build and all the tests pass : 

```bash
130/132 Test  #84: olympia_arch_small_core_32_custom_core ......................   Passed   43.13 sec
131/132 Test  #83: olympia_arch_small_core_32_custom_dhry_test .................   Passed   51.86 sec
132/132 Test #132: fusion_test .................................................   Passed  114.21 sec

100% tests passed, 0 tests failed out of 132

Total Test time (real) = 1064.84 sec
[100%] Built target regress
jha@MAGICIAN:~/workspace/packages/riscv-perf-model/release$
```

Thanks.